### PR TITLE
Adjust ingest module and fedora_to_rdf command line

### DIFF
--- a/bin/fedora_to_rof
+++ b/bin/fedora_to_rof
@@ -6,15 +6,23 @@ require 'optparse'
 # assign default parameter values
 fedora_info = {}
 config = {}
-thisPid = nil
 file_path = STDOUT
-config['download_content'] = false
-config['show_all'] = false
+config['download'] = false
+config['inline'] = false
+config['download_path'] = '.'
 
 # parse the command line
 #
 opt = OptionParser.new do |opts|
-  opts.banner = %q{Usage: fedora_to_rof --pid --fedora URL --user STRING --output_path STRING [ --download_content] [ --show_all ]}
+  opts.banner = %q{Usage: fedora_to_rof --fedora URL --user STRING --output DIR [--download | --inline]  PID [PID2 ...]
+
+Read the given PIDs from the given Fedora 3 instance, and then output them as
+ROF objects. By default output will be STDOUT, pass a directory in `--output`
+to save them as files. Datastreams smaller than 1024 bytes are added to the ROF
+file. Larger ones may either be included inline or saved as auxillary files.
+Use `--inline` to include them inline and use `--download` to save them as
+files. The files will have a name in the form `<pid>-<dsname>`.
+}
 
   opts.on("", "--fedora URL", "Base Fedora URL (including port number)") do |url|
     fedora_info[:url] = url
@@ -22,31 +30,28 @@ opt = OptionParser.new do |opts|
   opts.on("", "--user STRING", "Username and password (colon separated) for fedora") do |u|
     fedora_info[:user], fedora_info[:password] = u.split(':')
   end
-  opts.on("", "--download_content", "Download files <1K in size inline (defaults to false)") do
-   	config['download_content'] = true 
+  opts.on("", "--download DIRECTORY", "Save datastreams >1K in size to files (defaults to false)") do |directory|
+    config['download'] = true
+    config['download_path'] = directory
   end
-  opts.on("", "--show_all", "Include Unhandled Datastreams in ROF output  (defaults to false)") do
-   	config['show_all'] = true 
+  opts.on("", "--inline", "Include datastreams >1K in size in ROF output (defaults to false)") do
+    config['inline'] = true
   end
-  opts.on("", "--output_file PATH", "Desired file output path") do |output|
-	file_path = output
-  end
-  opts.on("", "--pid pid", "Desired pid from fedora") do |pid|
-	thisPid = pid
+  opts.on("", "--outfile FILENAME", "File to save ROF to") do |output|
+    file_path = output
   end
 end
 
 opt.parse!
 
+pids = ARGV
 fedora_info = nil if fedora_info.empty?
 
-# without a fedora and a pid, there is no reaso to proceed
-
-if fedora_info == nil || thisPid == nil then
-	STDERR.puts opt.help
-	exit 1
+# without a fedora and a pid, there is no reason to proceed
+if fedora_info == nil || pids.empty? then
+  STDERR.puts opt.help
+  exit 1
 end
 
-#perform conversion
-
-ROF::CLI.convert_to_rof(thisPid, fedora_info, file_path, config)
+# perform conversion
+ROF::CLI.convert_to_rof(pids, fedora_info, file_path, config)

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -72,19 +72,24 @@ module ROF
     end
 
     # retrieve fedora object and convert to ROF
-    def self.convert_to_rof(pid, fedora=nil, outfile=STDOUT, config)
-      # open output file if needed
+    def self.convert_to_rof(pids, fedora=nil, outfile=STDOUT, config={})
       need_close = false
-      # what is the use case for the /dev/null option???
-      outfile = "/dev/null" unless outfile
       # use outfile is_a String
-      if outfile != STDOUT
+      if outfile.is_a?(String)
         outfile = File.open(outfile , "w")
         need_close = true
       end
 
-      fedora_data =  ROF::FedoraToRof.GetFromFedora(pid, fedora, config)
-      outfile.write(JSON.pretty_generate(fedora_data))
+      # wrap the objects inside a JSON list
+      outfile.write("[\n")
+      first = true
+      pids.each do |pid|
+        outfile.write(",") unless first
+        fedora_data =  ROF::FedoraToRof.GetFromFedora(pid, fedora, config)
+        outfile.write(JSON.pretty_generate(fedora_data))
+        first = false
+      end
+      outfile.write("]\n")
     ensure
       outfile.close if outfile && need_close
     end

--- a/lib/rof/ingesters/rights_metadata_ingester.rb
+++ b/lib/rof/ingesters/rights_metadata_ingester.rb
@@ -44,7 +44,6 @@ module ROF
         content
       end
 
-      private
       def format_rights_section(section_name, people, groups)
         people = [people] if people.is_a? String
         groups = [groups] if groups.is_a? String

--- a/lib/rof/rdf_context.rb
+++ b/lib/rof/rdf_context.rb
@@ -11,4 +11,16 @@ module ROF
       "@type" => "http://www.w3.org/2001/XMLSchema#date"
     }
   }.freeze
+
+  RelsExtRefContext = {
+      "@vocab" => "info:fedora/fedora-system:def/relations-external#",
+      "fedora-model" => "info:fedora/fedora-system:def/model#",
+      "hydra" => "http://projecthydra.org/ns/relations#",
+      "hasModel" => {"@id" => "fedora-model:hasModel", "@type" => "@id"},
+      "hasEditor" => {"@id" => "hydra:hasEditor", "@type" => "@id"},
+      "hasEditorGroup" => {"@id" => "hydra:hasEditorGroup", "@type" => "@id"},
+      "isPartOf" => {"@type" => "@id"},
+      "isEditorOf" => {"@id" => "hydra:isEditorOf", "@type" => "@id"},
+      "hasMember" => {"@type" => "@id"},
+  }.freeze
 end

--- a/spec/lib/rof/cli_spec.rb
+++ b/spec/lib/rof/cli_spec.rb
@@ -18,15 +18,7 @@ describe ROF::CLI do
       "type" => "fobject",
       "af-model" => "GenericFile",
       "rels-ext" => {
-        "@context"=>{
-          "@vocab"=>"info:fedora/fedora-system:def/relations-external#",
-          "fedora-model"=>"info:fedora/fedora-system:def/model#",
-          "hydra"=>"http://projecthydra.org/ns/relations#",
-          "hasModel"=>{"@id"=>"fedora-model:hasModel", "@type"=>"@id"},
-          "hasEditor"=>{"@id"=>"hydra:hasEditor", "@type"=>"@id"},
-          "hasEditorGroup"=>{"@id"=>"hydra:hasEditorGroup", "@type"=>"@id"},
-          "isPartOf"=>{"@type"=>"@id"}
-        },
+        "@context"=> ROF::RelsExtRefContext,
         "isPartOf"=>["und:dev00128288"]
       },
       "rights" => {

--- a/spec/lib/rof/ingesters/rights_metadata_ingester_spec.rb
+++ b/spec/lib/rof/ingesters/rights_metadata_ingester_spec.rb
@@ -2,7 +2,36 @@ require 'spec_helper'
 
 module ROF
   module Ingesters
+
     describe RightsMetadataIngester do
+      before(:all) do
+        @rights_ingestor = RightsMetadataIngester.new(item:{})
+      end
+
+      it "formats people and groups" do
+        s = @rights_ingestor.format_rights_section("qwerty", "alice", ["bob", "carol"])
+        expect(s).to eq <<-EOS
+  <access type="qwerty">
+    <human/>
+    <machine>
+      <person>alice</person>
+      <group>bob</group>
+      <group>carol</group>
+    </machine>
+  </access>
+EOS
+      end
+
+      it "handles no people or groups" do
+        s = @rights_ingestor.format_rights_section("qwerty", nil, nil)
+        expect(s).to eq <<-EOS
+  <access type="qwerty">
+    <human/>
+    <machine/>
+  </access>
+EOS
+      end
+
       it "works with simple cases" do
         item = {"rights" => {"read-groups" => ["restricted", "abc"],
                              "read" => ["joe"],


### PR DESCRIPTION
- don't alter rels-ext if there is no model or rels-ext in the ROF
object.
- handle `@graph` in the Metadata section. (we must handle that
differently since we cannot supply a default `@id`)
- remove dead code for creating rightsMetadata datastreams
- Change `fedora_to_rof` download options. Now one can
    * Download large datastreams to files
    * Or include large datastreams inline
    * Or neither
    * Small datastreams are always included. (Not sure about that, but need a
use case for NOT including them).
- Add more default relations into the RELS-EXT json-ld `@context`, and
pull it into a common place. (doesn't _quite_ work right because the
download piece hates having a `@base` given of "info:fedora/".)