### PR TITLE
Don't generate new pids for labels in isMemberOfCollection

### DIFF
--- a/lib/rof/utility.rb
+++ b/lib/rof/utility.rb
@@ -52,14 +52,12 @@ module ROF
     end
 
     # set 'properties'
-    def self.prop_ds(owner, representative = nil)
-      s = %(<fields><depositor>batch_ingest</depositor>
-				<owner>#{owner}</owner>)
+    def self.prop_ds(owner, representative=nil)
+      s = "<fields><depositor>batch_ingest</depositor>\n<owner>#{owner}</owner>\n"
       if representative
-        s += "<representative>#{representative}</representative>\n</fields>\n"
-      else
-        s += "</fields>\n"
+        s += "<representative>#{representative}</representative>\n"
       end
+      s += "</fields>\n"
       s
     end
   end

--- a/spec/lib/rof/collection_spec.rb
+++ b/spec/lib/rof/collection_spec.rb
@@ -33,8 +33,8 @@ module ROF
 	it { is_expected.to eq("$(first)") }
       end
       context 'properties' do
-	subject { obj['properties'] }
-	it { is_expected.to match /<fields><depositor>batch_ingest<\/depositor>\n\t\t\t\t<owner>rtillman<\/owner><\/fields>\n/ }
+        subject { obj['properties'] }
+        it { is_expected.to eq "<fields><depositor>batch_ingest</depositor>\n<owner>rtillman</owner>\n</fields>\n" }
       end
       context 'properties--meta' do
 	subject { obj['properties-meta'] }

--- a/spec/lib/rof/filters/label_spec.rb
+++ b/spec/lib/rof/filters/label_spec.rb
@@ -31,7 +31,7 @@ module ROF
                  }}]
         expect(@labeler.process(list, '')).to eq([{"type" => "fobject",
                                                "pid" => "101",
-		 				"bendo-item"=>"101",
+                                               "bendo-item"=>"101",
                                                "rels-ext" => {
                                                   "partOf" => ["123", "101"]}}])
       end
@@ -43,15 +43,20 @@ module ROF
                  }},
                 {"type" => "fobject",
                  "rels-ext" => { "memberOf" => ["$(zzz)"]}}]
-        expect(@labeler.process(list, '')).to eq([{"type" => "fobject",
-                                               "pid" => "101",
-		 			       "bendo-item" =>"101",
-                                               "rels-ext" => {
-                                                  "partOf" => ["123", "101"]}},
-        {"type" => "fobject",
-         "pid" => "102",
-	 "bendo-item" =>"101",
-         "rels-ext" => { "memberOf" => ["101"]}}])
+        expect(@labeler.process(list, '')).to eq([
+              {"type" => "fobject",
+               "pid" => "101",
+               "bendo-item" => "101",
+               "rels-ext" => {
+                 "partOf" => ["123", "101"]
+               }},
+              {"type" => "fobject",
+               "pid" => "102",
+               "bendo-item" => "101",
+               "rels-ext" => {
+                 "memberOf" => ["101"]
+               }}
+              ])
       end
       it "errors on undefined labels" do
         list = [{"type" => "fobject",
@@ -72,6 +77,17 @@ module ROF
           sym: :symbol,
           b: {b: "abc $(z)"}
         })
+      end
+
+      it "handles pids in isMemberOf" do
+        list = [
+          {"type" => "fobject", "pid" => "$(zzz)"},
+          {"type" => "fobject", "rels-ext" => { "isMemberOfCollection" => ["$(zzz)"]}}
+        ]
+        expect(@labeler.process(list, '')).to eq([
+          {"type" => "fobject", "pid" => "101", "bendo-item" =>"101"},
+          {"type" => "fobject", "pid" => "102", "bendo-item" =>"101", "rels-ext" => { "isMemberOfCollection" => ["101"]}}
+        ])
       end
     end
   end

--- a/spec/lib/rof/utility_spec.rb
+++ b/spec/lib/rof/utility_spec.rb
@@ -19,7 +19,7 @@ module ROF
        let(:id) { util.next_label}
 
        it 'assigns initial label' do
-         id.should == '$(pid--0)'
+         expect(id).to eq '$(pid--0)'
        end
     end
 

--- a/spec/lib/rof/utility_spec.rb
+++ b/spec/lib/rof/utility_spec.rb
@@ -5,14 +5,14 @@ module ROF
     let(:util) { described_class.new }
 
     describe 'prop_ds' do
-      context 'set properties, representative is true' do
-        subject { described_class.prop_ds(owner: 'msuhovec', representative: true) }
-	it { is_expected.to match /<fields><depositor>batch_ingest<\/depositor>\n\t\t\t\t<owner>{:owner=>\"msuhovec\", :representative=>true}<\/owner><\/fields>\n/ }
+      context 'set properties with representative' do
+        subject { described_class.prop_ds('msuhovec', 'temp:1234') }
+        it { is_expected.to eq "<fields><depositor>batch_ingest</depositor>\n<owner>msuhovec</owner>\n<representative>temp:1234</representative>\n</fields>\n" }
       end
 
-      context 'set properties, representative is false' do
-        subject { described_class.prop_ds(owner: 'msuhovec', representative: false) }
-	it { is_expected.to match /<fields><depositor>batch_ingest<\/depositor>\n\t\t\t\t<owner>{:owner=>\"msuhovec\", :representative=>false}<\/owner><\/fields>\n/ }
+      context 'set properties without representative' do
+        subject { described_class.prop_ds('msuhovec') }
+        it { is_expected.to eq "<fields><depositor>batch_ingest</depositor>\n<owner>msuhovec</owner>\n</fields>\n" }
       end
     end
     describe 'next_label' do


### PR DESCRIPTION
* Ids were mistakenly being generated twice for any labels in RELS-EXT
with a `isMemberOfCollection` relation.
* consolidated the code assigning bendo-items to rof objects
* Fix rspec deprecation warning
* remove white space from properties datastream (this commit got mixed up with the others...sorry). Fixed test using the prop_ds method incorrectly.

DLTP-554