### PR TITLE
Dltp 603

### DIFF
--- a/lib/rof/compare_rof.rb
+++ b/lib/rof/compare_rof.rb
@@ -7,18 +7,18 @@ require 'rdf/isomorphic'
 module ROF
  class CompareRof
 
-   # compare fedora rof to bendo_rof
-   # return true in equivalent, false if not
-   def self.fedora_vs_bendo( fedora_rof, bendo_rof, output)
+    # compare fedora rof to bendo_rof
+    # return true in equivalent, false if not
+    def self.fedora_vs_bendo( fedora_rof, bendo_rof, output)
 
-     error_count = 0
-     # dereferencing an array of one element with [0]. Oh, the horror of it.
-     error_count += compare_rights( fedora_rof[0], bendo_rof[0], output)
-     error_count += compare_rels_ext(fedora_rof[0], bendo_rof[0], output)
-     error_count += compare_metadata(fedora_rof[0], bendo_rof[0], output)
-     error_count += compare_everything_else(fedora_rof[0], bendo_rof[0], output)
-     error_count
-   end
+      error_count = 0
+      # dereferencing an array of one element with [0]. Oh, the horror of it.
+      error_count += compare_rights( fedora_rof[0], bendo_rof[0], output)
+      error_count += compare_rels_ext(fedora_rof[0], bendo_rof[0])
+      error_count += compare_metadata(fedora_rof[0], bendo_rof[0])
+      error_count += compare_everything_else(fedora_rof[0], bendo_rof[0], output)
+      error_count
+    end
 
     # do rights comparison
     # return 0 if the same, >0 if different
@@ -48,22 +48,24 @@ module ROF
     end
 
     # convert RELS-EXT sections to RDF::graph and compater w/ rdf-isomorphic
-    def self.compare_rels_ext( fedora, bendo, output)
-      error_count =0
-      bendo['rels-ext']['@context'] = ROF::RelsExtRefContext.dup if ! bendo['rels-ext'].has_key?('@context')
-      fedora['rels-ext']['@context'] = ROF::RelsExtRefContext.dup if ! fedora['rels-ext'].has_key?('@context')
-      bendo_rdf = RDF::Graph.new << JSON::LD::API.toRdf(bendo['rels-ext'])
-      fedora_rdf = RDF::Graph.new << JSON::LD::API.toRdf(fedora['rels-ext'])
+    def self.compare_rels_ext(fedora, bendo)
+      error_count = 0
+      bendo_rdf = jsonld_to_rdf(bendo['rels-ext'], ROF::RelsExtRefContext)
+      fedora_rdf = jsonld_to_rdf(fedora['rels-ext'], ROF::RelsExtRefContext)
       error_count +=1 if ! bendo_rdf.isomorphic_with? fedora_rdf
       error_count
     end
     
+    def self.jsonld_to_rdf(doc, default_context)
+      doc["@context"] = default_context unless doc.has_key?("@context")
+      RDF::Graph.new << JSON::LD::API.toRdf(doc)
+    end
+
     # convert metadata sections to RDF::graph and compater w/ rdf-isomorphic
-    def self.compare_metadata( fedora, bendo, output)
-      error_count =0
-      bendo['metadata']['@context'] = ROF::RdfContext.dup
-      bendo_rdf = RDF::Graph.new << JSON::LD::API.toRdf(bendo['metadata'])
-      fedora_rdf = RDF::Graph.new << JSON::LD::API.toRdf(fedora['metadata'])
+    def self.compare_metadata(fedora, bendo)
+      error_count = 0
+      bendo_rdf = jsonld_to_rdf(bendo['metadata'], ROF::RdfContext)
+      fedora_rdf = jsonld_to_rdf(fedora['metadata'], ROF::RdfContext)
       error_count +=1 if ! bendo_rdf.isomorphic_with? fedora_rdf
       error_count
     end

--- a/lib/rof/compare_rof.rb
+++ b/lib/rof/compare_rof.rb
@@ -21,41 +21,30 @@ module ROF
    end
 
     # do rights comparison
+    # return 0 if the same, >0 if different
     def self.compare_rights( fedora_rof, bendo_rof, output )
 
       error_count =0
-     
+
       # Use same comparison scheme on all rights
-      [ 'read' , 'read-groups', 'edit', 'edit-groups', 'edit-users', 'embargo-date'].each { |attribute|
-        exist_count = rights_exist(attribute, fedora_rof, bendo_rof)
-	return 1 if exist_count == 1
-	error_count += rights_equal(attribute, fedora_rof, bendo_rof) if exist_count == 2
-	break if error_count != 0
-      }
+      [ 'read' , 'read-groups', 'edit', 'edit-groups', 'edit-users', 'embargo-date'].each do |attribute|
+        error_count += rights_equal(attribute, fedora_rof, bendo_rof)
+        break if error_count != 0
+      end
 
       error_count
-    end
-
-    # returns 2 is rights attribute exists in both fedora and bendo, 0 if in neither, 1 otherwise 
-    def self.rights_exist(rights_attr, fedora, bendo)
-      exist_count = 0
-      exist_count += 1 if fedora['rights'].has_key?(rights_attr)
-      exist_count += 1 if bendo['rights'].has_key?(rights_attr)
-      exist_count
     end
 
     # compare array or element for equivalence
     def self.rights_equal(rights_attr, fedora, bendo)
-      error_count = 0
+      f_rights = fedora.fetch('rights', {}).fetch(rights_attr, [])
+      b_rights = bendo.fetch('rights', {}).fetch(rights_attr, [])
 
-      # this should always be an array, except for embargo-date
-      if bendo['rights'][rights_attr].respond_to?('sort')
-        error_count +=1 if bendo['rights'][rights_attr].sort.to_s != fedora['rights'][rights_attr].sort.to_s 
-      else
-        error_count +=1 if bendo['rights'][rights_attr].to_s != fedora['rights'][rights_attr].to_s 
-      end
+      f_rights = f_rights.sort if f_rights.respond_to?(:"sort")
+      b_rights = b_rights.sort if b_rights.respond_to?(:"sort")
 
-      error_count
+      return 0 if f_rights == b_rights
+      1
     end
 
     # convert RELS-EXT sections to RDF::graph and compater w/ rdf-isomorphic

--- a/lib/rof/get_from_fedora.rb
+++ b/lib/rof/get_from_fedora.rb
@@ -109,7 +109,6 @@ module ROF
     graph.from_ntriples(data, format: :ntriples)
     JSON::LD::API::fromRdf(graph) do |expanded|
       result = JSON::LD::API.compact(expanded, RdfContext)
-      result.delete("@id")
       @fedora_info['metadata'] = result
     end
   end
@@ -166,7 +165,6 @@ module ROF
     # now strip the info:fedora/ prefix from the URIs
     strip_info_fedora(result)
     # remove extra items
-    result.delete("@id")
     result.delete("hasModel")
     @fedora_info['rels-ext'] = result
   end

--- a/spec/fixtures/rof/dev0012829m.rof
+++ b/spec/fixtures/rof/dev0012829m.rof
@@ -22,7 +22,7 @@
   "properties-meta": "text/xml",
   "content-meta": {
     "label": "bonnie+chauncey",
-    "mime_type": "application/octet-stream",
+    "mime-type": "application/octet-stream",
     "URL": "bendo:14000/item/dev0012826k/bonnie+chauncey"
   },
   "metadata": {

--- a/spec/lib/rof/cli_spec.rb
+++ b/spec/lib/rof/cli_spec.rb
@@ -19,6 +19,7 @@ describe ROF::CLI do
       "af-model" => "GenericFile",
       "rels-ext" => {
         "@context"=> ROF::RelsExtRefContext,
+        "@id" => "und:dev0012829m",
         "isPartOf"=> "und:dev00128288"
       },
       "rights" => {
@@ -41,6 +42,7 @@ describe ROF::CLI do
           "dc:created"=>{"@type"=>"http://www.w3.org/2001/XMLSchema#date"},
           "dc:modified" => {"@type" => "http://www.w3.org/2001/XMLSchema#date"}
         },
+        "@id" => "info:fedora/und:dev0012829m",
         "dc:dateSubmitted" => "2016-04-12Z",
         "dc:modified" => "2016-04-12Z",
         "dc:title" => "bonnie+chauncey"

--- a/spec/lib/rof/compare_rof_spec.rb
+++ b/spec/lib/rof/compare_rof_spec.rb
@@ -16,6 +16,13 @@ module ROF
       expect(test_return).to eq(0)
     end
 
+    it "compares rights metadata with different groups" do
+      fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
+      bendo = { "rights"=> {"edit"=> ["rtillman"]}}
+      test_return = CompareRof.compare_rights(fedora, bendo, {})
+      expect(test_return).to eq(1)
+    end
+
     it "compares metadata (same) " do
       fedora = { "metadata"=> { "@context"=> {
             "dc"=> "http://purl.org/dc/terms/",

--- a/spec/lib/rof/compare_rof_spec.rb
+++ b/spec/lib/rof/compare_rof_spec.rb
@@ -44,7 +44,7 @@ module ROF
           "dc:modified"=> "2016-07-22Z",
           "dc:title"=> "carmella.jpeg"
         }}
-      test_return = CompareRof.compare_metadata(fedora, bendo, {})
+      test_return = CompareRof.compare_metadata(fedora, bendo)
       expect(test_return).to eq(0)
     end
 
@@ -69,7 +69,36 @@ module ROF
           "dc:modified"=> "2016-07-23Z",
           "dc:title"=> "carmella.jpeg"
         }}
-      test_return = CompareRof.compare_metadata(fedora, bendo, {})
+      test_return = CompareRof.compare_metadata(fedora, bendo)
+      expect(test_return).to eq(1)
+    end
+
+    it "compares metadata (different types) " do
+      # dateSubmitted is a string literal in one and a date type in the other
+      fedora = { "metadata"=> { "@context"=> {
+                                  "dc"=> "http://purl.org/dc/terms/",
+                                  "foaf"=> "http://xmlns.com/foaf/0.1/",
+                                  "rdfs"=> "http://www.w3.org/2000/01/rdf-schema#",
+                                  "dc:dateSubmitted"=> {
+                                    "@type"=> "http://www.w3.org/2001/XMLSchema#date"
+                                  },
+                                  "dc:modified"=> {
+	                                "@type"=> "http://www.w3.org/2001/XMLSchema#date"
+	                              }
+                                },
+                                "dc:dateSubmitted"=> "2016-07-22Z",
+                                "dc:modified"=> "2016-07-22Z",
+                                "dc:title"=> "carmella.jpeg"
+                              }}
+      bendo = { "metadata"=> {
+                  "@context" => {
+                    "dc"=> "http://purl.org/dc/terms/",
+                  },
+                  "dc:dateSubmitted"=> "2016-07-22Z",
+                  "dc:modified"=> "2016-07-22Z",
+                  "dc:title"=> "carmella.jpeg"
+                }}
+      test_return = CompareRof.compare_metadata(fedora, bendo)
       expect(test_return).to eq(1)
     end
 
@@ -111,7 +140,7 @@ module ROF
 		      "und:dev00149x01"
 	            ]
 	}}
-      test_return = CompareRof.compare_rels_ext(fedora, bendo, {})
+      test_return = CompareRof.compare_rels_ext(fedora, bendo)
       expect(test_return).to eq(0)
     end
 
@@ -153,7 +182,7 @@ module ROF
 		      "und:dev00148x01"
 	            ]
 	}}
-      test_return = CompareRof.compare_rels_ext(fedora, bendo, {})
+      test_return = CompareRof.compare_rels_ext(fedora, bendo)
       expect(test_return).to eq(1)
     end
 


### PR DESCRIPTION
Few details with the rof comparison.

* Streamline rights comparison
* Don't convert arrays to strings just to compare them. Instead compare them element by element.
* Keep the "@id" element in both the metadata and rels-ext datastreams. Still undecided whether to use `info:fedora/` prefix or not on the ids. On one hand, that *is* what is stored in fedora. On the other hand, it is ugly and redundant.
* uniformize how json-ld is extracted from the rof data
* also fix some indenting 
* emove unused parameter `output`

work inspired by DLTP-603