### PR TITLE
Make fedora_to_rof generate json all at once

### DIFF
--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -81,15 +81,11 @@ module ROF
       end
 
       # wrap the objects inside a JSON list
-      outfile.write("[\n")
-      first = true
+      result = []
       pids.each do |pid|
-        outfile.write(',') unless first
-        fedora_data = ROF::FedoraToRof.GetFromFedora(pid, fedora, config)
-        outfile.write(JSON.pretty_generate(fedora_data))
-        first = false
+        result << ROF::FedoraToRof.GetFromFedora(pid, fedora, config)
       end
-      outfile.write("]\n")
+      outfile.write(JSON.pretty_generate(result))
     ensure
       outfile.close if outfile && need_close
     end


### PR DESCRIPTION
Then if there is some kind of error, we do not have a parital output to
the file.