### PR TITLE
Expanding mime-types to allow greater variance

### DIFF
--- a/rof.gemspec
+++ b/rof.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rdf-turtle"
   spec.add_dependency "rdf-isomorphic"
   spec.add_dependency "json-ld", "~> 2.0.0"
-  spec.add_dependency "mime-types", "~> 2.4.3"
+  spec.add_dependency "mime-types", "~> 2.4"
   spec.add_dependency "rubydora", "~> 1.8.1"
   spec.add_dependency "noids_client"
   spec.add_dependency 'deprecation', '~> 0.1'


### PR DESCRIPTION
I was hoping to leverage ROF::RdfContext in Sipity, but encountered a
conflict in Sipity's Gemfile declarations:

```console
Bundler could not find compatible versions for gem "mime-types":
  In snapshot (Gemfile.lock):
    mime-types (= 2.99.3)

  In Gemfile:
    mime-types (~> 2.6)

    rof was resolved to 1.0.4, which depends on
      mime-types (~> 2.4.3)
```