### PR TITLE
Dltp 774 update batch ingestor for registrations

### DIFF
--- a/lib/rof/osf_to_rof.rb
+++ b/lib/rof/osf_to_rof.rb
@@ -39,8 +39,7 @@ module ROF
 
     # reads a ttl file and makes it a JSON-LD file that we can parse
     def fetch_from_ttl(ttl_file)
-      graph = RDF::Turtle::Reader.open(ttl_file,
-                                       prefixes:  ROF::OsfPrefixList.dup)
+      graph = RDF::Turtle::Reader.open(ttl_file, prefixes:  ROF::OsfPrefixList.dup)
       JSON::LD::API.fromRdf(graph)
     end
 

--- a/lib/rof/osf_to_rof.rb
+++ b/lib/rof/osf_to_rof.rb
@@ -24,14 +24,19 @@ module ROF
     def call
       rof_array = []
       return {} if project.nil?
-      ttl_data = ttl_from_targz(project_identifier + '.ttl')
-      rof_array[0] = build_archive_record(ttl_data)
+      @ttl_data = ttl_from_targz(project_identifier + '.ttl')
+      rof_array[0] = build_archive_record
       rof_array
     end
 
     private
 
     attr_reader :config, :project
+
+    # this is an array- the addition elements are the contributor(s)
+    # @return [Array<Hash>]
+    # @see #ttl_from_targz
+    attr_reader :ttl_data
 
     def project_identifier
       project.fetch('project_identifier')
@@ -45,65 +50,63 @@ module ROF
 
     # extracts given ttl file from JHU tar.gz package
     # - assumed to live under data/obj/root
+    # @return [Array<Hash>] the first element is the "work" and the additional elements, if any, are the contributor(s)
     def ttl_from_targz(ttl_filename)
       package_dir = config.fetch('package_dir')
       ttl_path = File.join(project_identifier, 'data/obj/root', ttl_filename)
       ROF::Utility.file_from_targz(File.join(package_dir, project_identifier + '.tar.gz'), ttl_path)
-      ttl_data = fetch_from_ttl(File.join(package_dir, ttl_path))
-      # this is an array- the addition elements are the contributor(s)
-      ttl_data
+      fetch_from_ttl(File.join(package_dir, ttl_path))
     end
 
     # Maps RELS-EXT
-    def map_rels_ext(_ttl_data)
+    def map_rels_ext
       rels_ext = {}
       rels_ext['@context'] = ROF::RelsExtRefContext.dup
       rels_ext
     end
 
     # sets metadata
-    def map_metadata(ttl_data)
+    def map_metadata
       metadata = {}
       metadata['@context'] = ROF::RdfContext.dup
       # metdata derived from project ttl file
       metadata['dc:created'] = Time.iso8601(ttl_data[0][@osf_map['dc:created']][0]['@value']).to_date.iso8601 + 'Z'
       metadata['dc:title'] = ttl_data[0][@osf_map['dc:title']][0]['@value']
-      metadata['dc:description'] =
-        ttl_data[0][@osf_map['dc:description']][0]['@value']
-      metadata['dc:subject'] = map_subject(ttl_data[0])
+      metadata['dc:description'] = ttl_data[0][@osf_map['dc:description']][0]['@value']
+      metadata['dc:subject'] = map_subject
       # metadata derived from osf_projects data, passed from UI
       metadata['dc:source'] = 'https://osf.io/' + project_identifier
       metadata['dc:creator#adminstrative_unit'] = project['administrative_unit']
       metadata['dc:creator#affiliation'] = project['affiliation']
-      metadata['dc:creator'] = map_creator(ttl_data)
+      metadata['dc:creator'] = map_creator
       metadata
     end
 
     # Constructs OsfArchive Record from ttl_data, data from the UI form,
     # and task config data
-    def build_archive_record(ttl_data)
+    def build_archive_record
       this_rof = {}
       this_rof['owner'] = project['owner']
       this_rof['type'] = 'OsfArchive'
-      this_rof['rights'] = map_rights(ttl_data[0])
-      this_rof['rels-ext'] = map_rels_ext(ttl_data[0])
-      this_rof['metadata'] = map_metadata(ttl_data)
+      this_rof['rights'] = map_rights
+      this_rof['rels-ext'] = map_rels_ext
+      this_rof['metadata'] = map_metadata
       this_rof['files'] = [project_identifier + '.tar.gz']
       this_rof
     end
 
     # sets subject
-    def map_subject(ttl_data)
-      if ttl_data.key?(@osf_map['dc:subject'])
-        return ttl_data[@osf_map['dc:subject']][0]['@value']
+    def map_subject
+      if ttl_data[0].key?(@osf_map['dc:subject'])
+        return ttl_data[0][@osf_map['dc:subject']][0]['@value']
       end
       ''
     end
 
     # figures out the rights
-    def map_rights(ttl_data)
+    def map_rights
       rights = {}
-      if ttl_data[@osf_map['isPublic']][0]['@value'] == 'true'
+      if ttl_data[0][@osf_map['isPublic']][0]['@value'] == 'true'
         rights['read-groups'] = ['public']
       end
       rights
@@ -111,9 +114,10 @@ module ROF
 
     # sets the creator- needs to read another ttl for the User data
     # only contrubutors with isBibliographic true are considered
-    def map_creator(ttl_data)
+    def map_creator
       creator = []
       ttl_data[0][@osf_map['hasContributor']].each do |contributor|
+        # Looping through the primary document and the contributors
         ttl_data.each do |item|
           next unless item['@id'] == contributor['@id']
           if item[@osf_map['isBibliographic']][0]['@value'] == 'true'

--- a/lib/rof/osf_to_rof.rb
+++ b/lib/rof/osf_to_rof.rb
@@ -24,7 +24,7 @@ module ROF
     def call
       rof_array = []
       return {} if project.nil?
-      ttl_data = ttl_from_targz(project['project_identifier'] + '.ttl')
+      ttl_data = ttl_from_targz(project_identifier + '.ttl')
       rof_array[0] = build_archive_record(ttl_data)
       rof_array
     end
@@ -32,6 +32,10 @@ module ROF
     private
 
     attr_reader :config, :project
+
+    def project_identifier
+      project.fetch('project_identifier')
+    end
 
     # reads a ttl file and makes it a JSON-LD file that we can parse
     def fetch_from_ttl(ttl_file)
@@ -43,13 +47,10 @@ module ROF
     # extracts given ttl file from JHU tar.gz package
     # - assumed to live under data/obj/root
     def ttl_from_targz(ttl_filename)
-      id =  project['project_identifier']
-      ttl_path = File.join(id,
-                           'data/obj/root',
-                           ttl_filename)
-      ROF::Utility.file_from_targz(File.join(config['package_dir'], id + '.tar.gz'),
-                                   ttl_path)
-      ttl_data = fetch_from_ttl(File.join(config['package_dir'], ttl_path))
+      package_dir = config.fetch('package_dir')
+      ttl_path = File.join(project_identifier, 'data/obj/root', ttl_filename)
+      ROF::Utility.file_from_targz(File.join(package_dir, project_identifier + '.tar.gz'), ttl_path)
+      ttl_data = fetch_from_ttl(File.join(package_dir, ttl_path))
       # this is an array- the addition elements are the contributor(s)
       ttl_data
     end
@@ -72,7 +73,7 @@ module ROF
         ttl_data[0][@osf_map['dc:description']][0]['@value']
       metadata['dc:subject'] = map_subject(ttl_data[0])
       # metadata derived from osf_projects data, passed from UI
-      metadata['dc:source'] = 'https://osf.io/' + project['project_identifier']
+      metadata['dc:source'] = 'https://osf.io/' + project_identifier
       metadata['dc:creator#adminstrative_unit'] = project['administrative_unit']
       metadata['dc:creator#affiliation'] = project['affiliation']
       metadata['dc:creator'] = map_creator(ttl_data)
@@ -88,7 +89,7 @@ module ROF
       this_rof['rights'] = map_rights(ttl_data[0])
       this_rof['rels-ext'] = map_rels_ext(ttl_data[0])
       this_rof['metadata'] = map_metadata(ttl_data)
-      this_rof['files'] = [project['project_identifier'] + '.tar.gz']
+      this_rof['files'] = [project_identifier + '.tar.gz']
       this_rof
     end
 

--- a/lib/rof/osf_to_rof.rb
+++ b/lib/rof/osf_to_rof.rb
@@ -126,8 +126,8 @@ module ROF
 
     # read user ttl file, extract User's full name
     def map_user_from_ttl(file_subpath)
-      ttl_data = ttl_from_targz(File.basename(file_subpath))
-      ttl_data[0][@osf_map['hasFullName']][0]['@value']
+      user_ttl_data = ttl_from_targz(File.basename(file_subpath))
+      user_ttl_data[0][@osf_map['hasFullName']][0]['@value']
     end
   end
 end

--- a/spec/lib/rof/osf_to_rof_spec.rb
+++ b/spec/lib/rof/osf_to_rof_spec.rb
@@ -1,25 +1,35 @@
 require 'spec_helper'
 
 RSpec.describe ROF::OsfToRof do
-  it "converts  an OSF Archive tar,gz to an ROF", memfs: true do
-    #Test file dirs
-    test_dir = Dir.mktmpdir('FROM_OSF')
-    ttl_dir = FileUtils.mkdir_p(File.join(test_dir, 'b6psa/data/obj/root'))
+  #Test file dirs
+  let(:test_dir) { Dir.mktmpdir('FROM_OSF') }
+  let(:ttl_dir) { FileUtils.mkdir_p(File.join(test_dir, 'b6psa/data/obj/root')) }
 
-    # tar and ttl files
-    tar_file = File.join(test_dir, 'b6psa.tar.gz')
-    proj_ttl_file = File.join(ttl_dir, 'b6psa.ttl')
-    user_ttl_file = File.join(ttl_dir, 'qpru8.ttl')
+  # tar and ttl files
+  let(:tar_file) { File.join(test_dir, 'b6psa.tar.gz') }
+  let(:proj_ttl_file) { File.join(ttl_dir, 'b6psa.ttl') }
+  let(:user_ttl_file) { File.join(ttl_dir, 'qpru8.ttl') }
 
-    config = { 'package_dir' => "#{test_dir}" }
-    osf_project = {
+  let(:config) { { 'package_dir' => "#{test_dir}" } }
+  let(:osf_project) do
+    {
       "project_identifier" => "b6psa",
       "administrative_unit" => "Library",
       "owner" => "msuhovec",
       "affiliation" => "OddFellows Local 151",
       "status" => "submitted",
     }
+  end
+  around do |the_example|
+    FileUtils.cp('spec/fixtures/osf/b6psa.tar.gz', tar_file)
+    begin
+      the_example.call
+    ensure
+      FileUtils.remove_entry test_dir
+    end
+  end
 
+  it "converts  an OSF Archive tar,gz to an ROF", memfs: true do
     expected_rof = [{"owner"=>"msuhovec",
                      "type"=>"OsfArchive",
                      "rights"=>{"read-groups"=>["public"]},
@@ -59,23 +69,38 @@ RSpec.describe ROF::OsfToRof do
                                                  "dc:creator#affiliation"=>"OddFellows Local 151",
                                                  "dc:creator"=>["Mark Suhovecky"]},
                      "files"=>["b6psa.tar.gz"]}]
+    expect(File.exists?(proj_ttl_file)).to be false
+    expect(File.exists?(user_ttl_file)).to be false
 
-    FileUtils.cp('spec/fixtures/osf/b6psa.tar.gz', tar_file)
+    rof = ROF::OsfToRof.osf_to_rof(config, osf_project)
 
-    begin
-      expect(File.exists?(proj_ttl_file)).to be false
-      expect(File.exists?(user_ttl_file)).to be false
+    expect(rof).to eq( expected_rof )
 
-      rof = ROF::OsfToRof.osf_to_rof(config, osf_project)
+    # ingested history should be created
+    expect(File.exists?(proj_ttl_file)).to be true
+    expect(File.exists?(user_ttl_file)).to be true
+  end
 
-      expect(rof).to eq( expected_rof )
-
-      # ingested history should be created
-      expect(File.exists?(proj_ttl_file)).to be true
-      expect(File.exists?(user_ttl_file)).to be true
-    ensure
-      # remove the directory.
-      FileUtils.remove_entry test_dir
+  describe 'RELS-EXT["pav:previousVersion"]' do
+    let(:converter) { ROF::OsfToRof.new(config, osf_project, previous_pid_finder) }
+    let(:pid_of_previous_version) { '1234' }
+    describe 'when previous pid is found' do
+      let(:previous_pid_finder) { double(call: pid_of_previous_version) }
+      it 'will set rels-ext pav:previousVersion to the previous pid' do
+        rof = converter.call
+        rels_ext = rof[0].fetch('rels-ext')
+        expect(rels_ext.fetch('pav:previousVersion')).to eq(pid_of_previous_version)
+        expect(previous_pid_finder).to have_received(:call).with(converter.archive_type, converter.osf_project_identifier)
+      end
+    end
+    describe 'when previous pid is NOT found' do
+      let(:previous_pid_finder) { double(call: nil) }
+      it 'will not set rels-ext pav:previousVersion to the previous pid' do
+        rof = converter.call
+        rels_ext = rof[0].fetch('rels-ext')
+        expect { rels_ext.fetch('pav:previousVersion') }.to raise_error(KeyError)
+        expect(previous_pid_finder).to have_received(:call).with(converter.archive_type, converter.osf_project_identifier)
+      end
     end
   end
 end


### PR DESCRIPTION
This is a pull request to work towards the DLTP-721 / DLTP-774 closing out OSF Archiving. It includes refactoring and preparatory work for assigning the PID to pav:previousVersion from some independent function.

## Refactoring OsfToRof to use instance methods

@e80c767b83262aafd5e53636fcdf7d5ca211ba5f

This also helps remove the need for passing parameters to each of the
methods; These can now be set as instance variables.

Prior to this commit, if there were multiple processes running on the
same ruby thread, the following class instance variable could have
comingled between those invocations.

```ruby
@osf_map = ROF::OsfToNDMap
```

## Using a method for project_identifier

@7ee725f244cd487cab8881f453ca3d5b9b7fe9d1

Favoring a method to provide consistent access of data. A tweak is if a
project_identifier key does not exist, an exception will be thrown.

## Consolidating to one line

@f18bec6f6b9a45475b102d4bf14d9faa9fc2e14d


## Renaming variable for clarity

@2b6af03a7e7e8d3629b9aeacf85f02ac02f7eba7


## Refactoring OsfToRof for instance ttl_data

@8ddce61c0a824a25a0e975a3399bd0603609b7db

Instead of passing the ttl_data as parameters, set an instance
variable. I found it a bit confusing that throughout the code,
references to `ttl_data` could be either the full ttl_data (i.e. an
array) or an element of the original `ttl_data` (i.e. a Hash).

This is my attempt to clean that up and provide greater clarity.

## Renaming project_identifier to source_slug

@ca6de2dd6c4188d5dbf5d588645f0b4020d69c6d

There are two named concepts conflicting with each other.

The identifier:
* referring to an OSF Project (and not a registration)
* referring to the slug in the OSF url (eg https://osf.io/:identifier)

I am attempting to disambiguate these two concepts. The former being
the :osf_project_identifier ([as defined in CurateND][1]). The latter being
the :source_slug ([as alluded to in CurateND][2])

[1]:https://github.com/ndlib/curate_nd/blob/115efec2e046257282a86fe2cd98c7d229d04cf9/app/repository_models/osf_archive.rb#L106
[2]:https://github.com/ndlib/curate_nd/blob/115efec2e046257282a86fe2cd98c7d229d04cf9/app/repository_models/osf_archive.rb#L96

## Adding pseudo-code for setting previousVersion

@6a83197763aad3c12586c431d7bd2514aa922ccc

This does not yet work, but is helping determine what will need to be
implemented.

## Adding specs for assigning pav:previousVersion

@a13014a024d1a16687a899590d5e30e78965f169

This required a bit of reworking and refactoring of the existing code
to best assist in the testing.
