### PR TITLE
Adding default rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - rvm: "2.3.0"
     - rvm: "2.2.4"
 
-script: "bundle exec rspec"
+script: "bundle exec rake"
 
 notifications:
   irc: "irc.freenode.org#ndlib"

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,38 @@ begin
 rescue LoadError
   $stdout.puts "RSpec failed to load; You won't be able to run tests."
 end
+
+namespace :commitment do
+  task :configure_test_for_code_coverage do
+    ENV['COVERAGE'] = 'true'
+  end
+  desc "Check for code that can go faster"
+  task :fasterer do
+    require 'fasterer/file_traverser'
+    file_traverser = Fasterer::FileTraverser.new(nil)
+    file_traverser.traverse
+    if file_traverser.offenses_found?
+      $stderr.puts "You can make the code go faster, see above. You can add exceptions in .fasterer.yml"
+      abort
+    end
+  end
+  task :code_coverage do
+    require 'json'
+    COVERAGE_GOAL = 89
+    $stdout.puts "Checking code_coverage"
+    lastrun_filename = File.expand_path('../coverage/.last_run.json', __FILE__)
+    if File.exist?(lastrun_filename)
+      coverage_percentage = JSON.parse(File.read(lastrun_filename)).fetch('result').fetch('covered_percent').to_i
+      # We are presently at 89%; we will not go below
+      if coverage_percentage < COVERAGE_GOAL
+        abort("ERROR: Code Coverage Goal Not Met:\n\t#{coverage_percentage}%\tExpected\n\t100%\tActual")
+      else
+        $stdout.puts "Code Coverage Goal Met (#{COVERAGE_GOAL}%)"
+      end
+    else
+      abort "Expected #{lastrun_filename} to exist for code coverage"
+    end
+  end
+end
+
+task(default: ['commitment:configure_test_for_code_coverage', :spec, 'commitment:code_coverage'])

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,12 @@
 require "bundler/gem_tasks"
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.pattern = "./spec/**/*_spec.rb"
+    ENV['COVERAGE'] = 'true'
+  end
+  task default: :spec
+rescue LoadError
+  $stdout.puts "RSpec failed to load; You won't be able to run tests."
+end

--- a/rof.gemspec
+++ b/rof.gemspec
@@ -40,9 +40,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rdf-xsd', '~> 2.0.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "fasterer"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-its'
+  spec.add_development_dependency "simplecov"
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'equivalent-xml'

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,0 +1,17 @@
+## Generation Notes:
+##   This file was generated via the commitment:install generator. You are free
+##   and expected to change this file.
+if ENV['COV'] || ENV['COVERAGE'] || ENV['TRAVIS']
+  if ENV['TRAVIS']
+    require 'simplecov'
+    require "codeclimate-test-reporter"
+    SimpleCov.start do
+      formatter(
+        SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter, CodeClimate::TestReporter::Formatter])
+      )
+    end
+  elsif ENV['COV'] || ENV['COVERAGE']
+    require 'simplecov'
+    SimpleCov.start
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 GEM_ROOT = File.expand_path("../../", __FILE__)
 $:.unshift File.join(GEM_ROOT, "lib")
 
+require 'coverage_helper'
 require 'rspec/its'
 require 'rspec/matchers'
 require 'equivalent-xml'
@@ -30,4 +31,3 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
 end
-


### PR DESCRIPTION
## Adding default rake task

@348fb823566a6c2261e885a14f28cdff1de5f66e

There is a general assumption that running `rake` without arguments
will run the unit tests.

## Adding code coverage requirement

@f6e632b2a5b713668b69bf4c153335b893193994

At present we have 89% code coverage on our tests. Given that this is a
fundamental toolkit, I want us to move towards 100% coverage.
