### PR TITLE
Improving code coverage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,12 +27,12 @@ namespace :commitment do
   end
   task :code_coverage do
     require 'json'
-    COVERAGE_GOAL = 89
+    # We are presently at 90%; we will not go below
+    COVERAGE_GOAL = 90
     $stdout.puts "Checking code_coverage"
     lastrun_filename = File.expand_path('../coverage/.last_run.json', __FILE__)
     if File.exist?(lastrun_filename)
       coverage_percentage = JSON.parse(File.read(lastrun_filename)).fetch('result').fetch('covered_percent').to_i
-      # We are presently at 89%; we will not go below
       if coverage_percentage < COVERAGE_GOAL
         abort("ERROR: Code Coverage Goal Not Met:\n\t#{coverage_percentage}%\tExpected\n\t100%\tActual")
       else

--- a/lib/rof/filters/bendo.rb
+++ b/lib/rof/filters/bendo.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 module ROF
   module Filters
 
@@ -10,17 +8,17 @@ module ROF
       end
 
       # for *-meta objects containing "URL", sub in bendo string if provided
-      def process(obj_list, _fname)
+      def process(obj_list, *)
         # NOTE: This was refactored to short-circuit the loop. A side-effect is that the code
         # is now returning the same object as was passed in. The previous behavior was that a
         # new object_list was created via the #map! method.
         return obj_list unless @bendo
-        ends_meta = Regexp.new('(.+)-meta')
+        key_name_ends_in_meta_regexp = Regexp.new('(.+)-meta')
         obj_list.map! do |obj|
-          obj.map do |name, value|
-            if name =~ ends_meta
-              if obj[name]["URL"]
-                obj[name]["URL"] = obj[name]["URL"].sub("bendo:",@bendo)
+          obj.map do |key_name, value|
+            if key_name =~ key_name_ends_in_meta_regexp
+              if obj[key_name]["URL"]
+                obj[key_name]["URL"] = obj[key_name]["URL"].sub("bendo:", @bendo)
               end
             end
           end

--- a/lib/rof/filters/bendo.rb
+++ b/lib/rof/filters/bendo.rb
@@ -4,18 +4,14 @@ module ROF
   module Filters
 
     # If bendo server is set , add it into datasreams that contain an URl referencing bendo
-    #
     class Bendo
       def initialize(bendo=nil)
         @bendo = bendo
       end
 
+      # for *-meta objects containing "URL", sub in bendo string if provided
       def process(obj_list, _fname)
-
         ends_meta = Regexp.new('(.+)-meta')
-
-        # for *-meta objects containing "URL", sub in bendo string if provided
-
         obj_list.map! do |obj|
           obj.map do |name, value|
             if name =~ ends_meta
@@ -24,7 +20,6 @@ module ROF
               end
             end
           end
-          # print object
           obj
         end
       end

--- a/lib/rof/filters/bendo.rb
+++ b/lib/rof/filters/bendo.rb
@@ -11,11 +11,15 @@ module ROF
 
       # for *-meta objects containing "URL", sub in bendo string if provided
       def process(obj_list, _fname)
+        # NOTE: This was refactored to short-circuit the loop. A side-effect is that the code
+        # is now returning the same object as was passed in. The previous behavior was that a
+        # new object_list was created via the #map! method.
+        return obj_list unless @bendo
         ends_meta = Regexp.new('(.+)-meta')
         obj_list.map! do |obj|
           obj.map do |name, value|
             if name =~ ends_meta
-              if obj[name]["URL"] && @bendo
+              if obj[name]["URL"]
                 obj[name]["URL"] = obj[name]["URL"].sub("bendo:",@bendo)
               end
             end

--- a/spec/lib/rof/filters/bendo_spec.rb
+++ b/spec/lib/rof/filters/bendo_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'rof/filters/bendo'
+
+RSpec.describe ROF::Filters::Bendo do
+  describe '#process' do
+    subject { described_class.new(bendo).process(original_object_list) }
+    let(:original_object_list) do
+      [
+        { "content-meta" => { "URL" => "bendo:/item/12345/a/file.txt" } },
+        { "not_gonna_change" => { "URL" => "bendo:/item/12345/a/file.txt" } },
+        { "content-meta" => { "URL" => "somewhere:/item/12345/a/file.txt" } }
+      ]
+    end
+
+    context 'if bendo is set' do
+      let(:bendo) { 'http://bendo.host' }
+      it 'will replace "bendo:" with the given bendo string' do
+        expected_object_list = [
+          { "content-meta" => { "URL" => "#{bendo}/item/12345/a/file.txt" } },
+          { "not_gonna_change" => { "URL" => "bendo:/item/12345/a/file.txt" } },
+          { "content-meta" => { "URL" => "somewhere:/item/12345/a/file.txt" } }
+        ]
+        expect(subject).to eq(expected_object_list)
+      end
+    end
+
+    context 'if bendo is not set' do
+      let(:bendo) { nil }
+      it 'will not replace "bendo:" in any of the data entries' do
+        expect(subject).to eq(original_object_list)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Moving comment up to method

@f36dc37aad3182882984d7c67d7f99d35a0b18b1


## Refactoring to leverage short-circuit

ATTN: @dbrower regarding this commit.

@24d3de257561ecc8d9ac57b90070960f1c4123ee

A side-effect of this code refactor is that the method is now returning
the same object as was passed in (e.g. the input and output are the same
object in memory). The previous behavior was that a new object_list was
created via the #map! method.

## Adding specs for ROF::Bendo::Filter

@95a9ec3da719720c9c46e9638927bee0461db4f0

To ensure that I understood what was happening in the method, I wrote
the specs and did some minor refactoring to assist in my understanding
of the method.

## Tweaking coverage goal from 89% to 90%

@c3996b16c496540262f929239d4d11c57ff4e846
