### PR TITLE
Normalizing filter initialize and process

### DIFF
--- a/bin/rof
+++ b/bin/rof
@@ -53,22 +53,10 @@ when "ingest", "validate"
   error_count = ROF::CLI.ingest_file(ARGV[1], search_path, STDOUT, fedora_info, bendo_info)
   exit 1 if error_count > 0
 when "filter"
-  filter = case ARGV[1]
-           when "bendo"
-             ROF::Filters::Bendo.new(bendo_info)
-           when "datestamp"
-             ROF::Filters::DateStamp.new
-           when "file-to-url"
-             ROF::Filters::FileToUrl.new
-           when "label"
-             ROF::Filters::Label.new(prefix, noids)
-           when "work"
-             ROF::Filters::Work.new
-           else
-             STDERR.puts "Unknown filter #{ARGV[1]}"
-             exit 3
-           end
-  ROF::CLI.filter_file(filter, ARGV[2], STDOUT)
+  filter_name = ARGV[1]
+  file_name = ARGV[2]
+  filter = ROF::Filters.for(filter_name, file_name: file_name, bendo_info: bendo_info, prefix: prefix, noids: noids)
+  ROF::CLI.filter_file(filter, file_name, STDOUT)
 else
   STDERR.puts "Unknown command #{ARGV[0]}"
   STDERR.puts opt.help

--- a/lib/rof.rb
+++ b/lib/rof.rb
@@ -6,11 +6,7 @@ require "rof/collection"
 require "rof/utility"
 require "rof/rdf_context"
 require "rof/translators"
-require "rof/filters/date_stamp"
-require "rof/filters/file_to_url"
-require "rof/filters/label"
-require "rof/filters/work"
-require "rof/filters/bendo"
+require "rof/filters"
 
 module ROF
 end

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -61,12 +61,12 @@ module ROF
 
     def self.filter_file(filter, fname, outfile = STDOUT)
       items = load_items_from_file(fname, STDERR)
-      filter_array(filter, items, fname, outfile)
+      filter_array(filter, items, outfile)
     end
 
-    def self.filter_array(filter, items, fname, outfile = STDOUT)
+    def self.filter_array(filter, items, outfile = STDOUT)
       # filter will transform the items array in place
-      result = filter.process(items, fname)
+      result = filter.process(items)
       outfile.write(JSON.pretty_generate(result))
     end
 

--- a/lib/rof/filters.rb
+++ b/lib/rof/filters.rb
@@ -4,5 +4,25 @@ end
 
 module ROF
   module Filters
+    class UnknownFilterError < RuntimeError
+      def initialize(filter_name, available_filters)
+        super(%(Unable to find filter "#{filter_name}". Available filter names are: #{available_filters.inspect}))
+      end
+    end
+    AVAILABLE_FILTERS = {
+      "bendo" => ROF::Filters::Bendo,
+      "datestamp" => ROF::Filters::DateStamp,
+      "file-to-url" => ROF::Filters::FileToUrl,
+      "label" => ROF::Filters::Label,
+      "work" => ROF::Filters::Work,
+    }
+    def self.for(filter_name, options = {})
+      begin
+        filter = AVAILABLE_FILTERS.fetch(filter_name)
+      rescue KeyError
+        raise UnknownFilterError.new(filter_name, AVAILABLE_FILTERS.keys)
+      end
+      filter.new(options)
+    end
   end
 end

--- a/lib/rof/filters.rb
+++ b/lib/rof/filters.rb
@@ -1,0 +1,8 @@
+Dir.glob(File.expand_path('../filters/*.rb', __FILE__)).each do |filename|
+  require filename
+end
+
+module ROF
+  module Filters
+  end
+end

--- a/lib/rof/filters/bendo.rb
+++ b/lib/rof/filters/bendo.rb
@@ -3,12 +3,12 @@ module ROF
 
     # If bendo server is set , add it into datasreams that contain an URl referencing bendo
     class Bendo
-      def initialize(bendo=nil)
-        @bendo = bendo
+      def initialize(options = {})
+        @bendo = options.fetch(:bendo_info)
       end
 
       # for *-meta objects containing "URL", sub in bendo string if provided
-      def process(obj_list, *)
+      def process(obj_list)
         # NOTE: This was refactored to short-circuit the loop. A side-effect is that the code
         # is now returning the same object as was passed in. The previous behavior was that a
         # new object_list was created via the #map! method.

--- a/lib/rof/filters/date_stamp.rb
+++ b/lib/rof/filters/date_stamp.rb
@@ -6,8 +6,8 @@ module ROF
     # Also set the date modified to be the date given.
     # If not given, the date used defaults to the local time on the computer.
     class DateStamp
-      def initialize(date=nil)
-        @today = date || Date::today
+      def initialize(options = {})
+        @today = options.fetch(:as_of) { Date::today }
         @today_s = if @today.is_a?(Date)
                      @today.strftime('%FZ')
                    else
@@ -15,7 +15,7 @@ module ROF
                    end
       end
 
-      def process(obj_list, _fname)
+      def process(obj_list)
         obj_list.map! do |obj|
           if obj["metadata"].nil?
             obj["metadata"] = {

--- a/lib/rof/filters/file_to_url.rb
+++ b/lib/rof/filters/file_to_url.rb
@@ -6,10 +6,10 @@ module ROF
     # supposes the file keeps the same relative path the item originally had in
     # the rof file.
     class FileToUrl
-      def initialize()
+      def initialize(options = {})
       end
 
-      def process(obj_list, _fname)
+      def process(obj_list)
         obj_list.map! do |obj|
           bendo_item = obj['bendo-item']
           content_file = obj['content-file']

--- a/lib/rof/filters/label.rb
+++ b/lib/rof/filters/label.rb
@@ -23,7 +23,8 @@ module ROF
       #
       # If prefix is not nil, then "#{prefix}:" is prepended to
       # every identifier.
-      def initialize(prefix, options = {})
+      def initialize(options = {})
+        prefix = options.fetch(:prefix, nil)
         @id_list =  case
                     when options[:id_list]
                       options[:id_list]
@@ -39,7 +40,7 @@ module ROF
 
       # mutate obj_list by assigning labels and resolving labels where needed
       # Every fobject will be assigned an pid and a bendo_item
-      def process(obj_list, _fname)
+      def process(obj_list)
         labels = {}
 
         # Use two passes. First assign ids, and then resolve labels

--- a/lib/rof/filters/label.rb
+++ b/lib/rof/filters/label.rb
@@ -23,12 +23,12 @@ module ROF
       #
       # If prefix is not nil, then "#{prefix}:" is prepended to
       # every identifier.
-      def initialize(prefix, options)
+      def initialize(prefix, options = {})
         @id_list =  case
                     when options[:id_list]
                       options[:id_list]
                     when options[:noid_server]
-                      NoidsPool.new(options[:noid_server], options[:pool_name])
+                      NoidsPool.new(options[:noid_server], options.fetch(:pool_name))
                     else
                       raise NoPool
                     end

--- a/lib/rof/filters/work.rb
+++ b/lib/rof/filters/work.rb
@@ -12,13 +12,15 @@ module ROF
       class NoFile < RuntimeError
       end
 
-      def initialize
+      def initialize(options = {})
+        @file_name = options.fetch(:file_name)
         @utility = ROF::Utility.new
       end
+      attr_reader :file_name
 
       # wade through object list
-      def process(obj_list, filename)
-        @utility.set_workdir(filename)
+      def process(obj_list)
+        @utility.set_workdir(file_name)
         obj_list.map! { |x| process_one_work(x) }
         obj_list.flatten!
       end

--- a/spec/lib/rof/filters/bendo_spec.rb
+++ b/spec/lib/rof/filters/bendo_spec.rb
@@ -1,9 +1,17 @@
 require 'spec_helper'
 require 'rof/filters/bendo'
+require 'support/an_rof_filter'
 
 RSpec.describe ROF::Filters::Bendo do
+  it_behaves_like "an ROF::Filter"
+  let(:bendo){ nil }
+  let(:valid_options) { { bendo_info: bendo} }
+
+  it 'requires bendo_info to initialize' do
+    expect { described_class.new({}) }.to raise_error(KeyError)
+  end
   describe '#process' do
-    subject { described_class.new(bendo).process(original_object_list) }
+    subject { described_class.new(bendo_info: bendo).process(original_object_list) }
     let(:original_object_list) do
       [
         { "content-meta" => { "URL" => "bendo:/item/12345/a/file.txt" } },

--- a/spec/lib/rof/filters/date_stamp_spec.rb
+++ b/spec/lib/rof/filters/date_stamp_spec.rb
@@ -1,19 +1,23 @@
 require 'spec_helper'
+require 'support/an_rof_filter'
 
 module ROF
   module Filters
     describe DateStamp do
+      it_behaves_like "an ROF::Filter"
+      let(:valid_options) { {} }
+
       before(:all) do
         @today = Date.new(2015, 1, 23)
         @today_s = "2015-01-23Z"
-        @w = DateStamp.new(@today)
+        @w = DateStamp.new(as_of: @today)
       end
 
       it "it adds a metadata section if needed" do
         items = [{
           "type" => "ABC"
         }]
-        after = @w.process(items, '')
+        after = @w.process(items)
         expect(after.length).to eq(1)
         expect(after.first).to eq({
           "type" => "ABC",
@@ -32,7 +36,7 @@ module ROF
             "dc:title" => "something"
           }
         }]
-        after = @w.process(items, '')
+        after = @w.process(items)
         expect(after.length).to eq(1)
         expect(after.first).to eq({
           "type" => "BCD",
@@ -52,7 +56,7 @@ module ROF
             "dc:dateSubmitted" => "any date"
           }
         }]
-        after = @w.process(items, '')
+        after = @w.process(items)
         expect(after.length).to eq(1)
         expect(after.first).to eq({
           "type" => "CDE",
@@ -73,7 +77,7 @@ module ROF
             "dc:modified" => "any date"
           }
         }]
-        after = @w.process(items, '')
+        after = @w.process(items)
         expect(after.length).to eq(1)
         expect(after.first).to eq({
           "type" => "CDE",

--- a/spec/lib/rof/filters/file_to_url_spec.rb
+++ b/spec/lib/rof/filters/file_to_url_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
+require 'support/an_rof_filter'
 
 module ROF
   module Filters
     describe FileToUrl do
+      it_behaves_like "an ROF::Filter"
+      let(:valid_options) { {} }
+
       before(:all) do
         @w = FileToUrl.new
       end
@@ -11,7 +15,7 @@ module ROF
         items = [{
           "type" => "ABC"
         }]
-        after = @w.process(items, '')
+        after = @w.process(items)
         expect(after.length).to eq(1)
         expect(after.first).to eq({
           "type" => "ABC"
@@ -27,7 +31,7 @@ module ROF
           "bendo-item" => "12345",
           "thumbnail-content" => "a_file.png"
         }]
-        after = @w.process(items, '')
+        after = @w.process(items)
         expect(after.length).to eq(2)
         expect(after.first).to eq({
           "type" => "ABC",
@@ -49,7 +53,7 @@ module ROF
         "content-meta" => {
           "mime-type" => "image/png"
         }}]
-        after = @w.process(items, '')
+        after = @w.process(items)
         expect(after.length).to eq(2)
         expect(after.first).to eq({
           "bendo-item" => "12345",

--- a/spec/lib/rof/filters/label_spec.rb
+++ b/spec/lib/rof/filters/label_spec.rb
@@ -1,27 +1,30 @@
 require 'spec_helper'
+require 'support/an_rof_filter'
 
 module ROF
   module Filters
     describe Label do
+      it_behaves_like "an ROF::Filter"
+      let(:valid_options) { { id_list: ids } }
       let(:ids) { ["101", "102", "103", "104", "105"] }
       before(:each) {
-        @labeler = Label.new(nil, id_list: ids)
+        @labeler = Label.new(id_list: ids)
       }
       it "ignores non-fojects" do
         list = [{"type" => "not fobject"}]
-        expect(@labeler.process(list, '')).to eq([{"type" => "not fobject"}])
+        expect(@labeler.process(list)).to eq([{"type" => "not fobject"}])
       end
       it "skips already assigned ids" do
         list = [{"type" => "fobject", "pid" => "123"}]
-        expect(@labeler.process(list, '')).to eq([{"type" => "fobject", "pid" => "123", "bendo-item" => "123"}])
+        expect(@labeler.process(list)).to eq([{"type" => "fobject", "pid" => "123", "bendo-item" => "123"}])
       end
       it "assignes missing pids" do
         list = [{"type" => "fobject"}]
-        expect(@labeler.process(list, '')).to eq([{"type" => "fobject", "pid" => "101", "bendo-item" => "101"}])
+        expect(@labeler.process(list)).to eq([{"type" => "fobject", "pid" => "101", "bendo-item" => "101"}])
       end
       it "assignes pids which are labels" do
         list = [{"type" => "fobject", "pid" => "$(zzz)"}]
-        expect(@labeler.process(list, '')).to eq([{"type" => "fobject", "pid" => "101", "bendo-item" => "101"}])
+        expect(@labeler.process(list)).to eq([{"type" => "fobject", "pid" => "101", "bendo-item" => "101"}])
       end
       it "resolves loops" do
         list = [{"type" => "fobject",
@@ -29,7 +32,7 @@ module ROF
                  "rels-ext" => {
                     "partOf" => ["123", "$(zzz)"]
                  }}]
-        expect(@labeler.process(list, '')).to eq([{"type" => "fobject",
+        expect(@labeler.process(list)).to eq([{"type" => "fobject",
                                                "pid" => "101",
                                                "bendo-item"=>"101",
                                                "rels-ext" => {
@@ -43,7 +46,7 @@ module ROF
                  }},
                 {"type" => "fobject",
                  "rels-ext" => { "memberOf" => ["$(zzz)"]}}]
-        expect(@labeler.process(list, '')).to eq([
+        expect(@labeler.process(list)).to eq([
               {"type" => "fobject",
                "pid" => "101",
                "bendo-item" => "101",
@@ -63,7 +66,7 @@ module ROF
                  "rels-ext" => {
                     "partOf" => ["123", "$(zzz)"]
                  }}]
-        expect { @labeler.process(list, '') }.to raise_error(Label::MissingLabel)
+        expect { @labeler.process(list) }.to raise_error(Label::MissingLabel)
       end
 
       it "replaces labels in arrays" do
@@ -84,7 +87,7 @@ module ROF
           {"type" => "fobject", "pid" => "$(zzz)"},
           {"type" => "fobject", "rels-ext" => { "isMemberOfCollection" => ["$(zzz)"]}}
         ]
-        expect(@labeler.process(list, '')).to eq([
+        expect(@labeler.process(list)).to eq([
           {"type" => "fobject", "pid" => "101", "bendo-item" =>"101"},
           {"type" => "fobject", "pid" => "102", "bendo-item" =>"101", "rels-ext" => { "isMemberOfCollection" => ["101"]}}
         ])

--- a/spec/lib/rof/filters/work_spec.rb
+++ b/spec/lib/rof/filters/work_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
+require 'support/an_rof_filter'
 
 module ROF
   module Filters
     describe Work do
+      it_behaves_like "an ROF::Filter"
+      let(:valid_options) { { file_name: '' } }
       it "handles variant work types" do
-        w = Work.new
+        w = Work.new(valid_options)
 
         item = {"type" => "Work", "owner" => "user1"}
         after = w.process_one_work(item)
@@ -32,7 +35,7 @@ module ROF
       end
 
       it "makes the first file be the representative" do
-        w = Work.new
+        w = Work.new(valid_options)
 
         item = {"type" => "Work", "owner" => "user1", "files" => ["a.txt", "b.jpeg"]}
         after = w.process_one_work(item)
@@ -50,7 +53,7 @@ module ROF
       end
 
       it "decodes files correctly" do
-        w = Work.new
+        w = Work.new(valid_options)
 
         item = {
           "type" => "Work",
@@ -72,7 +75,7 @@ module ROF
         expect(after.length).to eq(3)
         expect(after[0]).to include("type" => "fobject",
                                     "af-model" => "GenericWork",
-				    "rels-ext" => {}, 
+				    "rels-ext" => {},
                                     "pid" => "$(pid--0)")
         expect(after[1]).to include("type" => "fobject",
                                     "af-model" => "GenericFile",

--- a/spec/lib/rof/filters_spec.rb
+++ b/spec/lib/rof/filters_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module ROF
+  RSpec.describe Filters do
+    describe '.for' do
+      it 'raises an exception when one is not registered' do
+        expect { described_class.for('obviously-not-valid') }.to raise_error(described_class::UnknownFilterError)
+      end
+      it 'instantiates a valid filter' do
+        expect(described_class.for('datestamp')).to be_a(ROF::Filters::DateStamp)
+      end
+    end
+  end
+end

--- a/spec/support/an_rof_filter.rb
+++ b/spec/support/an_rof_filter.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples 'an ROF::Filter' do
+  before do
+    raise 'valid_options must be set with `let(:valid_options)`' unless
+      defined? valid_options
+  end
+
+  subject { described_class.new(valid_options) }
+
+  it { is_expected.to respond_to(:process).with(1).arguments }
+end


### PR DESCRIPTION
## Consolidating require for filters

@672edb1a83acecda03abf20064d73b48c3a8cb82

Instead of deeper knowledge of the filters, consolidate that into the
ROF::Filters submodule

## Ensuring that we get a pool_name with a noid_server

@e35c2004991c64c21481c8d66311794b58d3d72b


## Normalizing ROF::Filters interface

@728894c0c5f6d76ad867de300cb2ee2c30dfc444

* Removing the case statement, preferring instead a lookup table
* Adding a shared spec enforcer to define the interface for filters
* Passing all valid options to the filters and letting them decide what
  to use
* Removing file name from process (it was a unique case and could be
  handled as part of the initialize)
