### PR TITLE
Adding coverage for compare rof

### DIFF
--- a/lib/rof/compare_rof.rb
+++ b/lib/rof/compare_rof.rb
@@ -9,20 +9,19 @@ module ROF
 
     # compare fedora rof to bendo_rof
     # return true in equivalent, false if not
-    def self.fedora_vs_bendo( fedora_rof, bendo_rof, output)
-
+    def self.fedora_vs_bendo(fedora_rof, bendo_rof, _output = nil)
       error_count = 0
       # dereferencing an array of one element with [0]. Oh, the horror of it.
-      error_count += compare_rights( fedora_rof[0], bendo_rof[0], output)
-      error_count += compare_rels_ext(fedora_rof[0], bendo_rof[0], output)
-      error_count += compare_metadata(fedora_rof[0], bendo_rof[0], output)
-      error_count += compare_everything_else(fedora_rof[0], bendo_rof[0], output)
+      error_count += compare_rights( fedora_rof[0], bendo_rof[0])
+      error_count += compare_rels_ext(fedora_rof[0], bendo_rof[0])
+      error_count += compare_metadata(fedora_rof[0], bendo_rof[0])
+      error_count += compare_everything_else(fedora_rof[0], bendo_rof[0])
       error_count
     end
 
     # do rights comparison
     # return 0 if the same, >0 if different
-    def self.compare_rights( fedora_rof, bendo_rof, output )
+    def self.compare_rights(fedora_rof, bendo_rof)
 
       error_count =0
 
@@ -46,9 +45,10 @@ module ROF
       return 0 if f_rights == b_rights
       1
     end
+    private_class_method :rights_equal
 
     # convert RELS-EXT sections to RDF::graph and compater w/ rdf-isomorphic
-    def self.compare_rels_ext(fedora, bendo, _output = nil)
+    def self.compare_rels_ext(fedora, bendo)
       error_count = 0
       bendo_rdf = jsonld_to_rdf(bendo['rels-ext'], ROF::RelsExtRefContext)
       fedora_rdf = jsonld_to_rdf(fedora['rels-ext'], ROF::RelsExtRefContext)
@@ -62,7 +62,7 @@ module ROF
     end
 
     # convert metadata sections to RDF::graph and compater w/ rdf-isomorphic
-    def self.compare_metadata(fedora, bendo, _output = nil)
+    def self.compare_metadata(fedora, bendo)
       error_count = 0
       bendo_rdf = jsonld_to_rdf(bendo['metadata'], ROF::RdfContext)
       fedora_rdf = jsonld_to_rdf(fedora['metadata'], ROF::RdfContext)
@@ -71,7 +71,7 @@ module ROF
     end
 
     # compare what remains
-    def self.compare_everything_else( fedora, bendo, output)
+    def self.compare_everything_else( fedora, bendo)
       error_count =0
       fedora = remove_others(fedora)
       bendo = remove_others(bendo)

--- a/lib/rof/compare_rof.rb
+++ b/lib/rof/compare_rof.rb
@@ -14,8 +14,8 @@ module ROF
       error_count = 0
       # dereferencing an array of one element with [0]. Oh, the horror of it.
       error_count += compare_rights( fedora_rof[0], bendo_rof[0], output)
-      error_count += compare_rels_ext(fedora_rof[0], bendo_rof[0])
-      error_count += compare_metadata(fedora_rof[0], bendo_rof[0])
+      error_count += compare_rels_ext(fedora_rof[0], bendo_rof[0], output)
+      error_count += compare_metadata(fedora_rof[0], bendo_rof[0], output)
       error_count += compare_everything_else(fedora_rof[0], bendo_rof[0], output)
       error_count
     end
@@ -48,21 +48,21 @@ module ROF
     end
 
     # convert RELS-EXT sections to RDF::graph and compater w/ rdf-isomorphic
-    def self.compare_rels_ext(fedora, bendo)
+    def self.compare_rels_ext(fedora, bendo, _output = nil)
       error_count = 0
       bendo_rdf = jsonld_to_rdf(bendo['rels-ext'], ROF::RelsExtRefContext)
       fedora_rdf = jsonld_to_rdf(fedora['rels-ext'], ROF::RelsExtRefContext)
       error_count +=1 if ! bendo_rdf.isomorphic_with? fedora_rdf
       error_count
     end
-    
+
     def self.jsonld_to_rdf(doc, default_context)
       doc["@context"] = default_context unless doc.has_key?("@context")
       RDF::Graph.new << JSON::LD::API.toRdf(doc)
     end
 
     # convert metadata sections to RDF::graph and compater w/ rdf-isomorphic
-    def self.compare_metadata(fedora, bendo)
+    def self.compare_metadata(fedora, bendo, _output = nil)
       error_count = 0
       bendo_rdf = jsonld_to_rdf(bendo['metadata'], ROF::RdfContext)
       fedora_rdf = jsonld_to_rdf(fedora['metadata'], ROF::RdfContext)

--- a/spec/lib/rof/compare_rof_spec.rb
+++ b/spec/lib/rof/compare_rof_spec.rb
@@ -6,33 +6,35 @@ module ROF
       it 'calls compare_rights, compare_rels_ext, compare_metadata, compare_everything_else accumulating errors' do
         fedora_rof = [:f]
         bendo_rof = [:b]
-        output = double
-        expect(described_class).to receive(:compare_rights).with(:f, :b, output).and_return(1)
-        expect(described_class).to receive(:compare_rels_ext).with(:f, :b, output).and_return(2)
-        expect(described_class).to receive(:compare_metadata).with(:f, :b, output).and_return(4)
-        expect(described_class).to receive(:compare_everything_else).with(:f, :b, output).and_return(8)
-        expect(described_class.fedora_vs_bendo(fedora_rof, bendo_rof, output)).to eq(1+2+4+8)
+        expect(described_class).to receive(:compare_rights).with(:f, :b).and_return(1)
+        expect(described_class).to receive(:compare_rels_ext).with(:f, :b).and_return(2)
+        expect(described_class).to receive(:compare_metadata).with(:f, :b).and_return(4)
+        expect(described_class).to receive(:compare_everything_else).with(:f, :b).and_return(8)
+        expect(described_class.fedora_vs_bendo(fedora_rof, bendo_rof)).to eq(1+2+4+8)
       end
     end
-    it "compares rights metadata different read-groups" do
-      fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
-      bendo = { "rights"=> {"read-groups"=> ["private"], "edit"=> ["rtillman"]}}
-      test_return = CompareRof.compare_rights(fedora, bendo, {})
-      expect(test_return).to eq(1)
-    end
 
-    it "compares rights metadata same read-groups" do
-      fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
-      bendo = { "rights"=> {"read-groups"=> ["public"], "edit"=> ["rtillman"]}}
-      test_return = CompareRof.compare_rights(fedora, bendo, {})
-      expect(test_return).to eq(0)
-    end
+    describe '#compare_rights' do
+      it "compares rights metadata different read-groups" do
+        fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
+        bendo = { "rights"=> {"read-groups"=> ["private"], "edit"=> ["rtillman"]}}
+        test_return = CompareRof.compare_rights(fedora, bendo)
+        expect(test_return).to eq(1)
+      end
 
-    it "compares rights metadata with different groups" do
-      fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
-      bendo = { "rights"=> {"edit"=> ["rtillman"]}}
-      test_return = CompareRof.compare_rights(fedora, bendo, {})
-      expect(test_return).to eq(1)
+      it "compares rights metadata same read-groups" do
+        fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
+        bendo = { "rights"=> {"read-groups"=> ["public"], "edit"=> ["rtillman"]}}
+        test_return = CompareRof.compare_rights(fedora, bendo)
+        expect(test_return).to eq(0)
+      end
+
+      it "compares rights metadata with different groups" do
+        fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
+        bendo = { "rights"=> {"edit"=> ["rtillman"]}}
+        test_return = CompareRof.compare_rights(fedora, bendo)
+        expect(test_return).to eq(1)
+      end
     end
 
     it "compares metadata (same) " do
@@ -231,7 +233,7 @@ module ROF
                "type"=> "fobject",
 	       "bendo-item"=> "dev00149w5f"
 	}
-      test_return = CompareRof.compare_everything_else(fedora, bendo, {})
+      test_return = CompareRof.compare_everything_else(fedora, bendo)
       expect(test_return).to eq(0)
     end
 
@@ -268,7 +270,7 @@ module ROF
                "type"=> "fobject",
 	       "bendo-item"=> "dev00149w5f"
 	}
-      test_return = CompareRof.compare_everything_else(fedora, bendo, {})
+      test_return = CompareRof.compare_everything_else(fedora, bendo)
       expect(test_return).to eq(1)
     end
   end

--- a/spec/lib/rof/compare_rof_spec.rb
+++ b/spec/lib/rof/compare_rof_spec.rb
@@ -3,14 +3,11 @@ require 'spec_helper'
 module ROF
   describe CompareRof do
     describe '.fedora_vs_bendo' do
-      it 'calls compare_rights, compare_rels_ext, compare_metadata, compare_everything_else accumulating errors' do
-        fedora_rof = [:f]
-        bendo_rof = [:b]
-        expect(described_class).to receive(:compare_rights).with(:f, :b).and_return(1)
-        expect(described_class).to receive(:compare_rels_ext).with(:f, :b).and_return(2)
-        expect(described_class).to receive(:compare_metadata).with(:f, :b).and_return(4)
-        expect(described_class).to receive(:compare_everything_else).with(:f, :b).and_return(8)
-        expect(described_class.fedora_vs_bendo(fedora_rof, bendo_rof)).to eq(1+2+4+8)
+      it 'is a convenience method' do
+        expect_any_instance_of(described_class).to receive(:error_count)
+        fedora = [:f]
+        bendo = [:b]
+        described_class.fedora_vs_bendo(fedora, bendo)
       end
     end
 
@@ -18,21 +15,21 @@ module ROF
       it "compares rights metadata different read-groups" do
         fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
         bendo = { "rights"=> {"read-groups"=> ["private"], "edit"=> ["rtillman"]}}
-        test_return = CompareRof.compare_rights(fedora, bendo)
+        test_return = described_class.new(fedora, bendo).error_count
         expect(test_return).to eq(1)
       end
 
       it "compares rights metadata same read-groups" do
         fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
         bendo = { "rights"=> {"read-groups"=> ["public"], "edit"=> ["rtillman"]}}
-        test_return = CompareRof.compare_rights(fedora, bendo)
+        test_return = described_class.new(fedora, bendo).error_count
         expect(test_return).to eq(0)
       end
 
       it "compares rights metadata with different groups" do
         fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
         bendo = { "rights"=> {"edit"=> ["rtillman"]}}
-        test_return = CompareRof.compare_rights(fedora, bendo)
+        test_return = described_class.new(fedora, bendo).error_count
         expect(test_return).to eq(1)
       end
     end
@@ -58,7 +55,7 @@ module ROF
           "dc:modified"=> "2016-07-22Z",
           "dc:title"=> "carmella.jpeg"
         }}
-      test_return = CompareRof.compare_metadata(fedora, bendo)
+      test_return = described_class.new(fedora, bendo).error_count
       expect(test_return).to eq(0)
     end
 
@@ -83,7 +80,7 @@ module ROF
           "dc:modified"=> "2016-07-23Z",
           "dc:title"=> "carmella.jpeg"
         }}
-      test_return = CompareRof.compare_metadata(fedora, bendo)
+      test_return = described_class.new(fedora, bendo).error_count
       expect(test_return).to eq(1)
     end
 
@@ -112,7 +109,7 @@ module ROF
                   "dc:modified"=> "2016-07-22Z",
                   "dc:title"=> "carmella.jpeg"
                 }}
-      test_return = CompareRof.compare_metadata(fedora, bendo)
+      test_return = described_class.new(fedora, bendo).error_count
       expect(test_return).to eq(1)
     end
 
@@ -154,7 +151,7 @@ module ROF
 		      "und:dev00149x01"
 	            ]
 	}}
-      test_return = CompareRof.compare_rels_ext(fedora, bendo)
+      test_return = described_class.new(fedora, bendo).error_count
       expect(test_return).to eq(0)
     end
 
@@ -196,7 +193,7 @@ module ROF
 		      "und:dev00148x01"
 	            ]
 	}}
-      test_return = CompareRof.compare_rels_ext(fedora, bendo)
+      test_return = described_class.new(fedora, bendo).error_count
       expect(test_return).to eq(1)
     end
 
@@ -233,7 +230,7 @@ module ROF
                "type"=> "fobject",
 	       "bendo-item"=> "dev00149w5f"
 	}
-      test_return = CompareRof.compare_everything_else(fedora, bendo)
+      test_return = described_class.new(fedora, bendo).error_count
       expect(test_return).to eq(0)
     end
 
@@ -270,7 +267,7 @@ module ROF
                "type"=> "fobject",
 	       "bendo-item"=> "dev00149w5f"
 	}
-      test_return = CompareRof.compare_everything_else(fedora, bendo)
+      test_return = described_class.new(fedora, bendo).error_count
       expect(test_return).to eq(1)
     end
   end

--- a/spec/lib/rof/compare_rof_spec.rb
+++ b/spec/lib/rof/compare_rof_spec.rb
@@ -1,7 +1,19 @@
 require 'spec_helper'
 
 module ROF
-  describe "Compare ROF" do
+  describe CompareRof do
+    describe '.fedora_vs_bendo' do
+      it 'calls compare_rights, compare_rels_ext, compare_metadata, compare_everything_else accumulating errors' do
+        fedora_rof = [:f]
+        bendo_rof = [:b]
+        output = double
+        expect(described_class).to receive(:compare_rights).with(:f, :b, output).and_return(1)
+        expect(described_class).to receive(:compare_rels_ext).with(:f, :b, output).and_return(2)
+        expect(described_class).to receive(:compare_metadata).with(:f, :b, output).and_return(4)
+        expect(described_class).to receive(:compare_everything_else).with(:f, :b, output).and_return(8)
+        expect(described_class.fedora_vs_bendo(fedora_rof, bendo_rof, output)).to eq(1+2+4+8)
+      end
+    end
     it "compares rights metadata different read-groups" do
       fedora = { "rights"=> { "read-groups"=> ["public"], "edit"=> ["rtillman"]}}
       bendo = { "rights"=> {"read-groups"=> ["private"], "edit"=> ["rtillman"]}}


### PR DESCRIPTION
## Adding coverage for comparing fedora and bendo

@403287697c5832916c7ac62e1d6d7d6d738e1724

It's a bunch of stubs, but helps to ensure a normalized interface

## Removing unused parameter

@21da72cc6aa77a50bbe26607fd1891f04368b6a1


## Reworking CompareRof to be an instance

@628a54ac66f563a389165a3436567eab1af3bcab

I'm working towards greater coverage. It's easier to get there with
instances (as they are easier to refactor than class methods).

http://blog.codeclimate.com/blog/2012/11/14/why-ruby-class-methods-resist-refactoring/
