### PR TITLE
Organizing osf to rof

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ namespace :commitment do
   task :code_coverage do
     require 'json'
     # Our goal is to stay at this coverage level or higher; As the level increases, we bump up the goal
-    COVERAGE_GOAL = 92
+    COVERAGE_GOAL = 93
     $stdout.puts "Checking code_coverage"
     lastrun_filename = File.expand_path('../coverage/.last_run.json', __FILE__)
     if File.exist?(lastrun_filename)

--- a/bin/csv_to_rof
+++ b/bin/csv_to_rof
@@ -22,5 +22,4 @@ end
 
 STDIN.set_encoding("UTF-8")
 csv_contents = STDIN.read
-rof = ROF::Translators.csv_to_rof(csv_contents)
-puts JSON.pretty_generate(rof)
+ROF::Translators.csv_to_rof(csv_contents, {}, STDOUT)

--- a/bin/fedora_to_rof
+++ b/bin/fedora_to_rof
@@ -55,7 +55,8 @@ end
 
 # perform conversion
 begin
-  ROF::Translators.fedora_to_rof(pids, fedora_info, file_path, config)
+  config[:fedora_connection_information] = fedora_info
+  ROF::CLI.fedora_to_rof(pids, config, file_path)
 rescue => e
   STDERR.puts "ERROR: #{e}"
   exit 1

--- a/bin/osf_to_rof
+++ b/bin/osf_to_rof
@@ -15,7 +15,7 @@ config['solr_url'] = 'http://localhost:8080/solr'
 # parse the command line
 #
 opt = OptionParser.new do |opts|
-  opts.banner = %q{Usage: osf_to_rof --solr_url --projectfile file --packagedir DIR  --outputdir DIR 
+  opts.banner = %q{Usage: osf_to_rof --solr_url --projectfile file --packagedir DIR  --outputdir DIR
 }
 
   opts.on("", "--project_file project_file", "osf_projects file provided by requestor (required)") do |project_file|
@@ -41,4 +41,4 @@ if  !FileTest.exists?(config['project_file']) then
 end
 
 # perform conversion
-ROF::CLI.osf_to_rof(config)
+ROF::CLI.osf_to_rof(config['project_file'], config)

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -73,7 +73,7 @@ module ROF
 
     # convert OSF archive tar.gz to rof file
     def self.osf_to_rof(config, outfile = STDOUT)
-      osf_projects = ROF::Utility.load_items_from_json_file(config['project_file'], outfile) if config.key?('project_file')
+      osf_projects = ROF::Utility.load_items_from_json_file(config.fetch('project_file'), outfile)
       rof_data = ROF::Translators::OsfToRof.osf_to_rof(config, osf_projects[0])
       outfile.write(JSON.pretty_generate(rof_data))
     end

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -74,13 +74,13 @@ module ROF
     end
 
     # convert OSF archive tar.gz to rof file
+    # @param [String] project_file - The path to the OSF Project file
     # @param [Hash] config
-    # @option config [String] :project_file The path to the OSF Project file
     # @param [NilClass, String, #write] outfile - where should we write things
     # @see .with_outfile_handling for details on outfile
-    def self.osf_to_rof(config, outfile = STDOUT)
-      osf_projects = ROF::Utility.load_items_from_json_file(config.fetch('project_file'), outfile)
-      result = ROF::Translators::OsfToRof.call(config, osf_projects[0])
+    def self.osf_to_rof(project_file, config = {}, outfile = STDOUT)
+      osf_projects = ROF::Utility.load_items_from_json_file(project_file, outfile)
+      result = ROF::Translators::OsfToRof.call(osf_projects[0], config)
       with_outfile_handling(outfile) do |writer|
         writer.write(JSON.pretty_generate(result))
       end

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -98,6 +98,18 @@ module ROF
       end
     end
 
+    # Convert the given CSV to ROF JSON document
+    # @param [String] The contents of a CSV file
+    # @param [Hash] config
+    # @param [NilClass, String, #write] outfile - where should we write things
+    # @see .with_outfile_handling for details on outfile
+    def self.csv_to_rof(csv, config = {}, outfile = STDOUT)
+      result = ROF::Translators::CsvToRof.call(csv, config)
+      with_outfile_handling(outfile) do |writer|
+        writer.write(JSON.pretty_generate(result))
+      end
+    end
+
     # compare two rofs
     def self.compare_files(file1, file2, outfile = STDOUT, _fedora, _bendo)
       fedora_rof = ROF::Utility.load_items_from_json_file(file1, outfile)

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -18,7 +18,7 @@ module ROF
     #
     # Returns the number of errors.
     def self.ingest_file(fname, search_paths = [], outfile = STDOUT, fedora = nil, bendo = nil)
-      items = load_items_from_file(fname, outfile)
+      items = load_items_from_json_file(fname, outfile)
       ingest_array(items, search_paths, outfile, fedora, bendo)
     end
 
@@ -60,7 +60,7 @@ module ROF
     end
 
     def self.filter_file(filter, fname, outfile = STDOUT)
-      items = load_items_from_file(fname, STDERR)
+      items = load_items_from_json_file(fname, STDERR)
       filter_array(filter, items, outfile)
     end
 
@@ -72,22 +72,22 @@ module ROF
 
     # convert OSF archive tar.gz to rof file
     def self.osf_to_rof(config, outfile = STDOUT)
-      osf_projects = load_items_from_file(config['project_file'], outfile) if config.key?('project_file')
+      osf_projects = load_items_from_json_file(config['project_file'], outfile) if config.key?('project_file')
       rof_data = ROF::Translators::OsfToRof.osf_to_rof(config, osf_projects[0])
       outfile.write(JSON.pretty_generate(rof_data))
     end
 
     # compare two rofs
     def self.compare_files(file1, file2, outfile = STDOUT, _fedora, _bendo)
-      fedora_rof = load_items_from_file(file1, outfile)
-      bendo_rof =  load_items_from_file(file2, outfile)
+      fedora_rof = load_items_from_json_file(file1, outfile)
+      bendo_rof =  load_items_from_json_file(file2, outfile)
 
       ROF::CompareRof.fedora_vs_bendo(fedora_rof, bendo_rof, outfile)
     end
 
     protected
 
-    def self.load_items_from_file(fname, outfile)
+    def self.load_items_from_json_file(fname, outfile)
       items = nil
       File.open(fname, 'r:UTF-8') do |f|
         items = JSON.parse(f.read)

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -87,7 +87,7 @@ module ROF
 
     protected
 
-    def self.load_items_from_json_file(fname, outfile)
+    def self.load_items_from_json_file(fname, outfile = STDERR)
       items = nil
       File.open(fname, 'r:UTF-8') do |f|
         items = JSON.parse(f.read)

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -86,8 +86,16 @@ module ROF
       end
     end
 
-    def self.fedora_to_rof(pids, fedora_info, outfile, config)
-      ROF::Translators.fedora_to_rof(pids, fedora_info, file_path, config)
+    # Convert the given fedora PIDs to ROF JSON document
+    # @param [Array] pids - The path to the OSF Project file
+    # @param [Hash] config
+    # @param [NilClass, String, #write] outfile - where should we write things
+    # @see .with_outfile_handling for details on outfile
+    def self.fedora_to_rof(pids, config = {}, outfile = STDOUT)
+      result = ROF::Translators::FedoraToRof.call(pids, config)
+      with_outfile_handling(outfile) do |writer|
+        writer.write(JSON.pretty_generate(result))
+      end
     end
 
     # compare two rofs

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -72,6 +72,9 @@ module ROF
     end
 
     # convert OSF archive tar.gz to rof file
+    # @param [Hash] config
+    # @option config [String] :project_file The path to the OSF Project file
+    # @param [#write] outfile
     def self.osf_to_rof(config, outfile = STDOUT)
       osf_projects = ROF::Utility.load_items_from_json_file(config.fetch('project_file'), outfile)
       rof_data = ROF::Translators::OsfToRof.osf_to_rof(config, osf_projects[0])

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -60,13 +60,15 @@ module ROF
       outfile.close if outfile && need_close
     end
 
+    # Responsible for loading the given :fname into an array of items, the processing
+    # those items via the :filter, and finally writing results to the :output
+    #
+    # @param [#process] filter - the object that processes the items loaded from the fname
+    # @param [String] fname - the filename from which to load items
+    # @param [#write] outfile - the object to which we will #write the processed items
+    # @return void
     def self.filter_file(filter, fname, outfile = STDOUT)
       items = ROF::Utility.load_items_from_json_file(fname, STDERR)
-      filter_array(filter, items, outfile)
-    end
-
-    def self.filter_array(filter, items, outfile = STDOUT)
-      # filter will transform the items array in place
       result = filter.process(items)
       outfile.write(JSON.pretty_generate(result))
     end

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -5,6 +5,7 @@ require 'rubydora'
 require 'rof/ingest'
 require 'rof/collection'
 require 'rof/translators'
+require 'rof/utility'
 module ROF
   module CLI
     # Ingest the file `fname` that is a level 0 rof file. It may contain any
@@ -18,7 +19,7 @@ module ROF
     #
     # Returns the number of errors.
     def self.ingest_file(fname, search_paths = [], outfile = STDOUT, fedora = nil, bendo = nil)
-      items = load_items_from_json_file(fname, outfile)
+      items = ROF::Utility.load_items_from_json_file(fname, outfile)
       ingest_array(items, search_paths, outfile, fedora, bendo)
     end
 
@@ -60,7 +61,7 @@ module ROF
     end
 
     def self.filter_file(filter, fname, outfile = STDOUT)
-      items = load_items_from_json_file(fname, STDERR)
+      items = ROF::Utility.load_items_from_json_file(fname, STDERR)
       filter_array(filter, items, outfile)
     end
 
@@ -72,31 +73,17 @@ module ROF
 
     # convert OSF archive tar.gz to rof file
     def self.osf_to_rof(config, outfile = STDOUT)
-      osf_projects = load_items_from_json_file(config['project_file'], outfile) if config.key?('project_file')
+      osf_projects = ROF::Utility.load_items_from_json_file(config['project_file'], outfile) if config.key?('project_file')
       rof_data = ROF::Translators::OsfToRof.osf_to_rof(config, osf_projects[0])
       outfile.write(JSON.pretty_generate(rof_data))
     end
 
     # compare two rofs
     def self.compare_files(file1, file2, outfile = STDOUT, _fedora, _bendo)
-      fedora_rof = load_items_from_json_file(file1, outfile)
-      bendo_rof =  load_items_from_json_file(file2, outfile)
+      fedora_rof = ROF::Utility.load_items_from_json_file(file1, outfile)
+      bendo_rof =  ROF::Utility.load_items_from_json_file(file2, outfile)
 
       ROF::CompareRof.fedora_vs_bendo(fedora_rof, bendo_rof, outfile)
-    end
-
-    protected
-
-    def self.load_items_from_json_file(fname, outfile = STDERR)
-      items = nil
-      File.open(fname, 'r:UTF-8') do |f|
-        items = JSON.parse(f.read)
-      end
-      items = [items] unless items.is_a? Array
-      items
-    rescue JSON::ParserError => e
-      outfile.puts("Error reading #{fname}:#{e}")
-      exit!(1)
     end
   end
 end

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -77,7 +77,7 @@ module ROF
     # @param [#write] outfile
     def self.osf_to_rof(config, outfile = STDOUT)
       osf_projects = ROF::Utility.load_items_from_json_file(config.fetch('project_file'), outfile)
-      rof_data = ROF::Translators::OsfToRof.osf_to_rof(config, osf_projects[0])
+      rof_data = ROF::Translators::OsfToRof.call(config, osf_projects[0])
       outfile.write(JSON.pretty_generate(rof_data))
     end
 

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -4,7 +4,7 @@ require 'json'
 require 'rubydora'
 require 'rof/ingest'
 require 'rof/collection'
-require 'rof/osf_to_rof'
+require 'rof/translators'
 module ROF
   module CLI
     # Ingest the file `fname` that is a level 0 rof file. It may contain any
@@ -73,7 +73,7 @@ module ROF
     # convert OSF archive tar.gz to rof file
     def self.osf_to_rof(config, outfile = STDOUT)
       osf_projects = load_items_from_file(config['project_file'], outfile) if config.key?('project_file')
-      rof_data = ROF::OsfToRof.osf_to_rof(config, osf_projects[0])
+      rof_data = ROF::Translators::OsfToRof.osf_to_rof(config, osf_projects[0])
       outfile.write(JSON.pretty_generate(rof_data))
     end
 

--- a/lib/rof/translator.rb
+++ b/lib/rof/translator.rb
@@ -1,0 +1,18 @@
+module ROF
+  # A translator is responsible for converting the input into the given output.
+  # The input and output need not be the same type (e.g. CSV to Hash)
+  #
+  # @todo This is a work in progress; I will be normalizing the .call behavior.
+  #
+  # @see ROF::Translators::CsvToRof
+  # @see ROF::Translators::FedoraToRof
+  # @see ROF::Translators::OsfToRof
+  class Translator
+    # @param [Object] input - the thing that will be processed
+    # @param [Hash] config - a Hash with symbol keys
+    # @return [Hash] often times a Hash that can be serialized into JSON
+    def self.call(input, config = {})
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/rof/translators.rb
+++ b/lib/rof/translators.rb
@@ -1,12 +1,15 @@
-require 'rof/translators/csv_to_rof'
-require 'rof/translators/fedora_to_rof'
-require 'rof/translators/osf_to_rof'
+Dir.glob(File.expand_path('../translators/*.rb', __FILE__)).each do |filename|
+  require filename
+end
 
 module ROF
   # A namespace for organizing translating classes. A translating class is responsible for
   # converting from one format to another format (e.g. CSV to ROF).
   #
+  # @see ROF::Translator
   # @see ROF::Translators::CsvToRof
+  # @see ROF::Translators::FedoraToRof
+  # @see ROF::Translators::OsfToRof
   module Translators
     # @api public
     # @param csv_contents [String] in the form of a CSV

--- a/lib/rof/translators.rb
+++ b/lib/rof/translators.rb
@@ -13,10 +13,11 @@ module ROF
   module Translators
     # @api public
     # @param [String] csv_contents - in the form of a CSV
+    # @param [Hash] config - Hash with symbols for keys
     # @return [Hash] in ROF format
     # @see ROF::Translators::CsvToRof for full details
-    def self.csv_to_rof(csv_contents)
-      CsvToRof.call(csv_contents)
+    def self.csv_to_rof(csv_contents, config = {})
+      CsvToRof.call(csv_contents, config)
     end
 
     # @api public

--- a/lib/rof/translators.rb
+++ b/lib/rof/translators.rb
@@ -12,7 +12,7 @@ module ROF
   # @see ROF::Translators::OsfToRof
   module Translators
     # @api public
-    # @param csv_contents [String] in the form of a CSV
+    # @param [String] csv_contents - in the form of a CSV
     # @return [Hash] in ROF format
     # @see ROF::Translators::CsvToRof for full details
     def self.csv_to_rof(csv_contents)

--- a/lib/rof/translators.rb
+++ b/lib/rof/translators.rb
@@ -1,5 +1,6 @@
 require 'rof/translators/csv_to_rof'
 require 'rof/translators/fedora_to_rof'
+require 'rof/translators/osf_to_rof'
 
 module ROF
   # A namespace for organizing translating classes. A translating class is responsible for

--- a/lib/rof/translators.rb
+++ b/lib/rof/translators.rb
@@ -19,18 +19,5 @@ module ROF
     def self.csv_to_rof(csv_contents, config = {})
       CsvToRof.call(csv_contents, config)
     end
-
-    # @api public
-    #
-    # Write to the output file an ROF JSON document
-    #
-    # @param pids [Array] Fedora PIDs
-    # @param fedora [nil, Hash] Hash with connection information (e.g. URL, User)
-    # @param outfile [String, (#write, #close)] A String that is interpretted as a path to a file. Else an IO object responding to #write and #close
-    # @param config [Hash]
-    # @return Void
-    def self.fedora_to_rof(pids, fedora = nil, outfile = STDOUT, config = {})
-      FedoraToRof.call(pids, fedora, outfile, config)
-    end
   end
 end

--- a/lib/rof/translators/csv_to_rof.rb
+++ b/lib/rof/translators/csv_to_rof.rb
@@ -1,3 +1,4 @@
+require 'rof/translator'
 require('csv')
 require('json')
 

--- a/lib/rof/translators/csv_to_rof.rb
+++ b/lib/rof/translators/csv_to_rof.rb
@@ -46,7 +46,7 @@ module ROF::Translators
     class NoPriorWork < RuntimeError
     end
 
-    def self.call(csv_contents)
+    def self.call(csv_contents, config = {})
       first_line = nil
       rof_contents = []
       previous_work = nil

--- a/lib/rof/translators/csv_to_rof.rb
+++ b/lib/rof/translators/csv_to_rof.rb
@@ -32,7 +32,7 @@ module ROF::Translators
   # with the previous work translated into ROF. This will allow a work to have
   # attached files with different access permissions, owners, etc...
   # Any extra files are appended to the file list for the work.
-  class CsvToRof
+  class CsvToRof < ROF::Translator
     class MissingOwnerOrType < RuntimeError
     end
 

--- a/lib/rof/translators/fedora_to_rof.rb
+++ b/lib/rof/translators/fedora_to_rof.rb
@@ -8,7 +8,7 @@ require 'rof/translator'
 module ROF
   module Translators
     # Responsible for translating Fedora PIDs to ROF objects
-    class FedoraToRof
+    class FedoraToRof < ROF::Translator
       # @param [Array] pids - Fedora PIDs
       # @param [Hash] config - Hash with symbol keys
       # @option config [Hash] :fedora_connection_information - The Hash that contains the connection information for Fedora

--- a/lib/rof/translators/fedora_to_rof.rb
+++ b/lib/rof/translators/fedora_to_rof.rb
@@ -7,29 +7,20 @@ require 'rof/translator'
 
 module ROF
   module Translators
+    # Responsible for translating Fedora PIDs to ROF objects
     class FedoraToRof
-      # @param pids [Array] Fedora PIDs
-      # @param fedora [nil, Hash] Hash with connection information (e.g. URL, User)
-      # @param outfile [String, (#write, #close)] A String that is interpretted as a path to a file. Else an IO object responding to #write and #close
-      # @param config [Hash]
-      # @return Void
-      def self.call(pids, fedora = nil, outfile = STDOUT, config = {})
-        need_close = false
-        # use outfile is_a String
-        if outfile.is_a?(String)
-          outfile = File.open(outfile, 'w')
-          need_close = true
-        end
-
-        rof = new(pids, fedora, config).to_rof
-        outfile.write(JSON.pretty_generate(rof))
-      ensure
-        outfile.close if outfile && need_close
+      # @param [Array] pids - Fedora PIDs
+      # @param [Hash] config - Hash with symbol keys
+      # @option config [Hash] :fedora_connection_information - The Hash that contains the connection information for Fedora
+      # @return [Hash] The ROF representation of teh Fedora objects
+      # @see Rubydora.connect
+      def self.call(pids, config = {})
+        new(pids, config).to_rof
       end
 
-      def initialize(pids, fedora_connection_information, config)
+      def initialize(pids, config = {})
         @pids = pids
-        @fedora_connection_information = fedora_connection_information
+        @fedora_connection_information = config.fetch(:fedora_connection_information)
         @config = config
         connect_to_fedora!
       end

--- a/lib/rof/translators/fedora_to_rof.rb
+++ b/lib/rof/translators/fedora_to_rof.rb
@@ -3,6 +3,7 @@ require 'rexml/document'
 require 'rdf/ntriples'
 require 'rdf/rdfxml'
 require 'rubydora'
+require 'rof/translator'
 
 module ROF
   module Translators

--- a/lib/rof/translators/osf_to_rof.rb
+++ b/lib/rof/translators/osf_to_rof.rb
@@ -17,7 +17,7 @@ module ROF::Translators
     end
 
     # Convert Osf Archive tar.gz  to ROF
-    def self.osf_to_rof(config, osf_projects = nil, previously_archived_pid_finder = default_previously_archived_pid_finder)
+    def self.call(config, osf_projects = nil, previously_archived_pid_finder = default_previously_archived_pid_finder)
       new(config, osf_projects, previously_archived_pid_finder).call
     end
 

--- a/lib/rof/translators/osf_to_rof.rb
+++ b/lib/rof/translators/osf_to_rof.rb
@@ -6,7 +6,7 @@ require 'rof/osf_context'
 require 'rof/rdf_context'
 require 'rof/utility'
 
-module ROF
+module ROF::Translators
   # Class for managing OSF Archive data transformations
   # It is called after the get-from-osf task, and before the work-xlat task
   class OsfToRof
@@ -122,7 +122,7 @@ module ROF
     # @see https://github.com/ndlib/curate_nd/blob/115efec2e046257282a86fe2cd98c7d229d04cf9/spec/repository_models/osf_archive_spec.rb#L97
     def apply_previous_archived_version_if_applicable(rels_ext)
       # If a previously archived pid was passed in, use it to set pav:previousVersion
-      # If not, check SOLR for one.   
+      # If not, check SOLR for one.
       pid = previously_archived_pid_finder.call(archive_type, osf_project_identifier)
       pid = ROF::Utility.check_solr_for_previous(config, osf_project_identifier) if pid.nil?
       rels_ext['pav:previousVersion'] = pid if pid

--- a/lib/rof/translators/osf_to_rof.rb
+++ b/lib/rof/translators/osf_to_rof.rb
@@ -18,13 +18,13 @@ module ROF::Translators
     end
 
     # Convert Osf Archive tar.gz  to ROF
-    def self.call(config, osf_projects = nil, previously_archived_pid_finder = default_previously_archived_pid_finder)
-      new(config, osf_projects, previously_archived_pid_finder).call
+    def self.call(project, config, previously_archived_pid_finder = default_previously_archived_pid_finder)
+      new(project, config, previously_archived_pid_finder).call
     end
 
-    def initialize(config, osf_projects = nil, previously_archived_pid_finder = self.class.default_previously_archived_pid_finder)
+    def initialize(project, config, previously_archived_pid_finder = self.class.default_previously_archived_pid_finder)
       @config = config
-      @project = osf_projects
+      @project = project
       @previously_archived_pid_finder = previously_archived_pid_finder
       @osf_map = ROF::OsfToNDMap
     end

--- a/lib/rof/translators/osf_to_rof.rb
+++ b/lib/rof/translators/osf_to_rof.rb
@@ -5,6 +5,7 @@ require 'rdf/turtle'
 require 'rof/osf_context'
 require 'rof/rdf_context'
 require 'rof/utility'
+require 'rof/translator'
 
 module ROF::Translators
   # Class for managing OSF Archive data transformations

--- a/lib/rof/translators/osf_to_rof.rb
+++ b/lib/rof/translators/osf_to_rof.rb
@@ -10,7 +10,7 @@ require 'rof/translator'
 module ROF::Translators
   # Class for managing OSF Archive data transformations
   # It is called after the get-from-osf task, and before the work-xlat task
-  class OsfToRof
+  class OsfToRof < ROF::Translator
     # @todo Set this to be something more meaningful than an empty lambda
     # @return [#call]
     def self.default_previously_archived_pid_finder

--- a/lib/rof/utility.rb
+++ b/lib/rof/utility.rb
@@ -71,6 +71,22 @@ module ROF
       true
     end
 
+    # @api public
+    # @param fname [String] Path to filename
+    # @param outfile [#puts] Where to write exceptions
+    # @return [Array] The items in the JSON document, coerced into an Array (if a single item was encountered)
+    def self.load_items_from_json_file(fname, outfile = STDERR)
+      items = nil
+      File.open(fname, 'r:UTF-8') do |f|
+        items = JSON.parse(f.read)
+      end
+      items = [items] unless items.is_a? Array
+      items
+    rescue JSON::ParserError => e
+      outfile.puts("Error reading #{fname}:#{e}")
+      exit!(1)
+    end
+
     # query SOLR for Previous version of OSF Project.
     # Return its fedora pid if it is found, nil otherwise
     def self.check_solr_for_previous(config, osf_project_identifier)

--- a/spec/fixtures/for_utility_load_items_from_json_file/multiple_items.json
+++ b/spec/fixtures/for_utility_load_items_from_json_file/multiple_items.json
@@ -1,0 +1,8 @@
+[
+  {
+    "hello": "world"
+  },
+  {
+    "good": "bye"
+  }
+]

--- a/spec/fixtures/for_utility_load_items_from_json_file/parse_error.json
+++ b/spec/fixtures/for_utility_load_items_from_json_file/parse_error.json
@@ -1,0 +1,3 @@
+{
+  'hello': 'world'
+}

--- a/spec/fixtures/for_utility_load_items_from_json_file/single_item.json
+++ b/spec/fixtures/for_utility_load_items_from_json_file/single_item.json
@@ -1,0 +1,3 @@
+{
+  "hello": "world"
+}

--- a/spec/lib/rof/cli_spec.rb
+++ b/spec/lib/rof/cli_spec.rb
@@ -18,11 +18,12 @@ describe ROF::CLI do
     let(:outfile) { double(write: true) }
     let(:data_from_file) { [:data_from_file] }
     let(:rof_data) { [{ "rof" => "true" }] }
+    let(:config) { {} }
+    let(:project_file) { File.join(GEM_ROOT, 'spec/fixtures/for_utility_load_items_from_json_file/single_item.json') }
     it 'loads the JSON file, calls the translator then writes the output as JSON' do
-      config = { 'project_file' => File.join(GEM_ROOT, 'spec/fixtures/for_utility_load_items_from_json_file/single_item.json') }
-      expect(ROF::Utility).to receive(:load_items_from_json_file).with(config.fetch('project_file'), outfile).and_return(data_from_file)
-      expect(ROF::Translators::OsfToRof).to receive(:call).with(config, data_from_file[0]).and_return(rof_data)
-      described_class.osf_to_rof(config, outfile)
+      expect(ROF::Utility).to receive(:load_items_from_json_file).with(project_file, outfile).and_return(data_from_file)
+      expect(ROF::Translators::OsfToRof).to receive(:call).with(data_from_file[0], config).and_return(rof_data)
+      described_class.osf_to_rof(project_file, config, outfile)
       expect(outfile).to have_received(:write).with(JSON.pretty_generate(rof_data))
     end
   end

--- a/spec/lib/rof/cli_spec.rb
+++ b/spec/lib/rof/cli_spec.rb
@@ -40,6 +40,18 @@ describe ROF::CLI do
     end
   end
 
+  describe '.csv_to_rof' do
+    let(:outfile) { double(write: true) }
+    let(:csv) { "1,2,3" }
+    let(:rof_data) { [{ "rof" => "true" }] }
+    let(:config) { {} }
+    it 'calls the translator then writes the output as JSON' do
+      expect(ROF::Translators::CsvToRof).to receive(:call).with(csv, config).and_return(rof_data)
+      described_class.csv_to_rof(csv, config, outfile)
+      expect(outfile).to have_received(:write).with(JSON.pretty_generate(rof_data))
+    end
+  end
+
   describe '.with_outfile_handling' do
     let(:writer) { double(close: true) }
     context 'when given a string' do

--- a/spec/lib/rof/cli_spec.rb
+++ b/spec/lib/rof/cli_spec.rb
@@ -26,4 +26,30 @@ describe ROF::CLI do
       expect(outfile).to have_received(:write).with(JSON.pretty_generate(rof_data))
     end
   end
+
+  describe '.with_outfile_handling' do
+    let(:writer) { double(close: true) }
+    context 'when given a string' do
+      let(:outfile) { '/hello/world' }
+      it 'will open a file' do
+        expect(File).to receive(:open).with('/hello/world', 'w').and_return(writer)
+        expect {|b| described_class.with_outfile_handling(outfile, &b) }.to yield_with_args(writer)
+        expect(writer).to have_received(:close)
+      end
+    end
+    context 'when given nil' do
+      let(:outfile) { nil }
+      it 'will write to /dev/null' do
+        expect(File).to receive(:open).with('/dev/null', 'w').and_return(writer)
+        expect {|b| described_class.with_outfile_handling(outfile, &b) }.to yield_with_args(writer)
+        expect(writer).to have_received(:close)
+      end
+    end
+    context 'when given something else' do
+      it 'will assume it is can be "written" to' do
+        expect {|b| described_class.with_outfile_handling(writer, &b) }.to yield_with_args(writer)
+        expect(writer).to have_received(:close)
+      end
+    end
+  end
 end

--- a/spec/lib/rof/cli_spec.rb
+++ b/spec/lib/rof/cli_spec.rb
@@ -21,7 +21,7 @@ describe ROF::CLI do
     it 'loads the JSON file, calls the translator then writes the output as JSON' do
       config = { 'project_file' => File.join(GEM_ROOT, 'spec/fixtures/for_utility_load_items_from_json_file/single_item.json') }
       expect(ROF::Utility).to receive(:load_items_from_json_file).with(config.fetch('project_file'), outfile).and_return(data_from_file)
-      expect(ROF::Translators::OsfToRof).to receive(:osf_to_rof).with(config, data_from_file[0]).and_return(rof_data)
+      expect(ROF::Translators::OsfToRof).to receive(:call).with(config, data_from_file[0]).and_return(rof_data)
       described_class.osf_to_rof(config, outfile)
       expect(outfile).to have_received(:write).with(JSON.pretty_generate(rof_data))
     end

--- a/spec/lib/rof/cli_spec.rb
+++ b/spec/lib/rof/cli_spec.rb
@@ -2,13 +2,28 @@ require 'spec_helper'
 require 'stringio'
 
 describe ROF::CLI do
-  it "ingests an array of items" do
-    items = [{"pid" => "test:1",
-              "type" => "fobject"},
-             {"pid" => "test:2",
-              "type" => "fobject"}]
-    output = StringIO.new
-    ROF::CLI.ingest_array(items, [], output)
-    expect(output.string).to match(/1\. Verifying test:1 \.\.\.ok\..*\n2\. Verifying test:2 \.\.\.ok\./)
+  describe '.ingest_array' do
+    it "ingests an array of items" do
+      items = [{"pid" => "test:1",
+                "type" => "fobject"},
+               {"pid" => "test:2",
+                "type" => "fobject"}]
+      output = StringIO.new
+      ROF::CLI.ingest_array(items, [], output)
+      expect(output.string).to match(/1\. Verifying test:1 \.\.\.ok\..*\n2\. Verifying test:2 \.\.\.ok\./)
+    end
+  end
+
+  describe '.osf_to_rof' do
+    let(:outfile) { double(write: true) }
+    let(:data_from_file) { [:data_from_file] }
+    let(:rof_data) { [{ "rof" => "true" }] }
+    it 'loads the JSON file, calls the translator then writes the output as JSON' do
+      config = { 'project_file' => File.join(GEM_ROOT, 'spec/fixtures/for_utility_load_items_from_json_file/single_item.json') }
+      expect(ROF::Utility).to receive(:load_items_from_json_file).with(config.fetch('project_file'), outfile).and_return(data_from_file)
+      expect(ROF::Translators::OsfToRof).to receive(:osf_to_rof).with(config, data_from_file[0]).and_return(rof_data)
+      described_class.osf_to_rof(config, outfile)
+      expect(outfile).to have_received(:write).with(JSON.pretty_generate(rof_data))
+    end
   end
 end

--- a/spec/lib/rof/cli_spec.rb
+++ b/spec/lib/rof/cli_spec.rb
@@ -28,6 +28,18 @@ describe ROF::CLI do
     end
   end
 
+  describe '.fedora_to_rof' do
+    let(:outfile) { double(write: true) }
+    let(:pids) { [1, 2, 3] }
+    let(:rof_data) { [{ "rof" => "true" }] }
+    let(:config) { {} }
+    it 'calls the translator then writes the output as JSON' do
+      expect(ROF::Translators::FedoraToRof).to receive(:call).with(pids, config).and_return(rof_data)
+      described_class.fedora_to_rof(pids, config, outfile)
+      expect(outfile).to have_received(:write).with(JSON.pretty_generate(rof_data))
+    end
+  end
+
   describe '.with_outfile_handling' do
     let(:writer) { double(close: true) }
     context 'when given a string' do

--- a/spec/lib/rof/translator_spec.rb
+++ b/spec/lib/rof/translator_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'rof/translator'
+
+module ROF
+  RSpec.describe Translator do
+    let(:input) { double }
+    let(:config) { double }
+    describe '.call' do
+      subject { described_class.call(input, config) }
+      it 'is an abstract method' do
+        expect { subject }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end

--- a/spec/lib/rof/translators/fedora_to_rof_spec.rb
+++ b/spec/lib/rof/translators/fedora_to_rof_spec.rb
@@ -3,10 +3,12 @@ require 'spec_helper'
 RSpec.describe ROF::Translators::FedoraToRof do
   let(:outfile) { double(close: true, write: true) }
   let(:pid) { 'und:dev0012829m' }
+  let(:config) { { fedora_connection_information: fedora_connection_information } }
+  let(:fedora_connection_information) { { url: 'http://localhost:8080/fedora', user: 'fedoraAdmin', password: 'fedoraAdmin' } }
+
   it 'will fail to initialize without a valid fedora connection' do
-    fedora = double
-    allow(Rubydora).to receive(:connect).with(fedora).and_raise('Woof')
-    expect { described_class.new([pid], fedora, {}) }.to raise_error('Woof')
+    allow(Rubydora).to receive(:connect).with(fedora_connection_information).and_raise('Woof')
+    expect { described_class.new([pid], config) }.to raise_error('Woof')
   end
 
   describe '.call' do
@@ -54,14 +56,8 @@ RSpec.describe ROF::Translators::FedoraToRof do
         "characterization-meta" => {"mime-type"=>"text/xml"},
         "thumbnail-meta" => {"label"=>"File Datastream", "mime-type"=>"image/png"},
       }]
-      config = {}
-      fedora = {}
-      fedora[:url] = 'http://localhost:8080/fedora'
-      fedora[:user] = 'fedoraAdmin'
-      fedora[:password] = 'fedoraAdmin'
       VCR.use_cassette("fedora_to_rof1") do
-        described_class.call([pid], fedora, outfile, config)
-        expect(outfile).to have_received(:write).with(JSON.pretty_generate(expected_output))
+        expect(described_class.call([pid], config)).to eq(expected_output)
       end
     end
   end

--- a/spec/lib/rof/translators/osf_to_rof_spec.rb
+++ b/spec/lib/rof/translators/osf_to_rof_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ROF::OsfToRof do
+RSpec.describe ROF::Translators::OsfToRof do
   #Test file dirs
   let(:test_dir) { Dir.mktmpdir('FROM_OSF') }
   let(:ttl_dir) { FileUtils.mkdir_p(File.join(test_dir, 'b6psa/data/obj/root')) }
@@ -75,7 +75,7 @@ RSpec.describe ROF::OsfToRof do
     expect(File.exists?(proj_ttl_file)).to be false
     expect(File.exists?(user_ttl_file)).to be false
 
-    rof = ROF::OsfToRof.osf_to_rof(config, osf_project)
+    rof = ROF::Translators::OsfToRof.osf_to_rof(config, osf_project)
 
     expect(rof).to eq( expected_rof )
 
@@ -85,7 +85,7 @@ RSpec.describe ROF::OsfToRof do
   end
 
   describe 'RELS-EXT["pav:previousVersion"]' do
-    let(:converter) { ROF::OsfToRof.new(config, osf_project, previous_pid_finder) }
+    let(:converter) { ROF::Translators::OsfToRof.new(config, osf_project, previous_pid_finder) }
     let(:pid_of_previous_version) { '1234' }
     describe 'when previous pid is found' do
       let(:previous_pid_finder) { double(call: pid_of_previous_version) }

--- a/spec/lib/rof/translators/osf_to_rof_spec.rb
+++ b/spec/lib/rof/translators/osf_to_rof_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ROF::Translators::OsfToRof do
     expect(File.exists?(proj_ttl_file)).to be false
     expect(File.exists?(user_ttl_file)).to be false
 
-    rof = ROF::Translators::OsfToRof.call(config, osf_project)
+    rof = ROF::Translators::OsfToRof.call(osf_project, config)
 
     expect(rof).to eq( expected_rof )
 
@@ -85,7 +85,7 @@ RSpec.describe ROF::Translators::OsfToRof do
   end
 
   describe 'RELS-EXT["pav:previousVersion"]' do
-    let(:converter) { ROF::Translators::OsfToRof.new(config, osf_project, previous_pid_finder) }
+    let(:converter) { ROF::Translators::OsfToRof.new(osf_project, config, previous_pid_finder) }
     let(:pid_of_previous_version) { '1234' }
     describe 'when previous pid is found' do
       let(:previous_pid_finder) { double(call: pid_of_previous_version) }

--- a/spec/lib/rof/translators/osf_to_rof_spec.rb
+++ b/spec/lib/rof/translators/osf_to_rof_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ROF::Translators::OsfToRof do
     expect(File.exists?(proj_ttl_file)).to be false
     expect(File.exists?(user_ttl_file)).to be false
 
-    rof = ROF::Translators::OsfToRof.osf_to_rof(config, osf_project)
+    rof = ROF::Translators::OsfToRof.call(config, osf_project)
 
     expect(rof).to eq( expected_rof )
 

--- a/spec/lib/rof/translators_spec.rb
+++ b/spec/lib/rof/translators_spec.rb
@@ -5,8 +5,9 @@ module ROF
     describe '.csv_to_rof' do
       it 'delegates to CsvToRof.call' do
         contents = double
-        expect(described_class::CsvToRof).to receive(:call).with(contents)
-        described_class.csv_to_rof(contents)
+        config = double
+        expect(described_class::CsvToRof).to receive(:call).with(contents, config)
+        described_class.csv_to_rof(contents, config)
       end
     end
 

--- a/spec/lib/rof/translators_spec.rb
+++ b/spec/lib/rof/translators_spec.rb
@@ -10,16 +10,5 @@ module ROF
         described_class.csv_to_rof(contents, config)
       end
     end
-
-    describe '.fedora_to_rof' do
-      it 'delegates to FedoraToRof.call' do
-        contents = double
-        fedora = double
-        outfile = double
-        config = double
-        expect(described_class::FedoraToRof).to receive(:call).with(contents, fedora, outfile, config)
-        described_class.fedora_to_rof(contents, fedora, outfile, config)
-      end
-    end
   end
 end

--- a/spec/lib/rof/utility_spec.rb
+++ b/spec/lib/rof/utility_spec.rb
@@ -23,6 +23,35 @@ module ROF
        end
     end
 
+    describe '.load_items_from_json_file' do
+      let(:logger) { double(puts: true) }
+      subject { described_class.load_items_from_json_file(filename, logger) }
+      context 'with a parse error' do
+        let(:filename) { File.join(GEM_ROOT, 'spec/fixtures/for_utility_load_items_from_json_file/parse_error.json') }
+        it 'will log the error and abort' do
+          expect(described_class).to receive(:exit!)
+          subject
+          expect(logger).to have_received(:puts).with(kind_of(String))
+        end
+      end
+      context 'with a single item' do
+        let(:filename) { File.join(GEM_ROOT, 'spec/fixtures/for_utility_load_items_from_json_file/single_item.json') }
+        it 'will return an Array' do
+          expect(described_class).not_to receive(:exit!)
+          expect(subject).to eq([{ "hello" => "world" }])
+          expect(logger).not_to have_received(:puts).with(kind_of(String))
+        end
+      end
+      context 'with a multiple items' do
+        let(:filename) { File.join(GEM_ROOT, 'spec/fixtures/for_utility_load_items_from_json_file/multiple_items.json') }
+        it 'will return an Array' do
+          expect(described_class).not_to receive(:exit!)
+          expect(subject).to eq([{ "hello" => "world" }, { "good" => "bye" }])
+          expect(logger).not_to have_received(:puts).with(kind_of(String))
+        end
+      end
+    end
+
     describe '.has_embargo_date?' do
       it 'handles embargo presence or absence' do
         rights_tests = [


### PR DESCRIPTION
## Moving module space

@36332a16cd8d27c409ced1c855ef71c8be3884ed


## Renaming method to reflect purpose

@10eb9ce7a1984ce0307dfe6e4ed02c65277cc617


## Provide a default for loading errors

@91c1b62e800e56dda18c1976593c211ea3604f49


## Extracting method to Utility file for testing

@c8e17ce34229dbb5ef35aeb33a64fe218f51476c


## Switching from Hash#[] Hash#fetch

@c857478e19037ad768d945ded954d102808c53ce

If the Hash didn't have a key, it would return nil, which would in turn
raise an exception on the next line. This instead removes a conditional
and eases the code a bit.

## Adding CLI spec for osf_to_rof

@c59dad692f6a648af1dc8942680189bcb96bf5c5


## Renaming method from .osf_to_rof to .call

@85cd0785e5af6d027ca6f1760e6d4a7207ad7394


## Consolidating method, adding additional documentation

@3e8a0666f0318ae403cc70386361b3bdd83f8e58


## Adding ROF::Translator

@ad522f99858fb945e029ac535f9fc3034ad6ebf3

I'm looking to normalize the interface of the translators; At present
they have developed organically. As we look to add more into the fold
I want to normalize those interactions -- to remove surprises when
working across translators, keeping layers of behavior separate, and
providing more unified guidance on creating ./bin scripts

Although it is functional, it is a work in progress.

## Normalizing how outfiles are handled via CLI

@5dc1b1a1575acea6fcb97775ac88ec7a35632d88


## Changing parameter order

@465468f7883c562b53cc4f2f6d10336d4ce85f9d

As I'm exploring the translators, I want the first parameter to be
the object and the second parameter to be the configuration.

```ruby
module ROF
  class Translator
    def self.call(input, config = {})
      # Do the magic
    end
  end
end
```

## Normalizing CsvToRof.call method signature

@6e17624828cb5666782bba2d18915cfc8a80c570


## Normalizing FedoraToRof behavior to that of OsfToRof

@14268d865c8631b6f830a0c1baf2ead4b56bd424


## Normalizing CLI for CSV to ROF

@3a7d0a6ee66f59c41965e332064c809b4295782b


## Adding inheritance to translators

@be7a21dd3ad0923e2fb6ba04014d589cf0514abf


## Bumping code coverage threshold

@ec8634b00cf91b6bfab78890de6431ed3f892955

