### PR TITLE
Ensuring that embargo date is a string

### DIFF
--- a/spec/fixtures/DLTP-999/pr76f190f54.jsonld
+++ b/spec/fixtures/DLTP-999/pr76f190f54.jsonld
@@ -81,6 +81,7 @@
         "@id": "_:b1"
       },
       "nd:accessEdit": "curate_batch_user",
+      "nd:accessEmbargoDate": "2016-11-16",
       "nd:accessRead": "wma1",
       "nd:accessReadGroup": "public",
       "nd:afmodel": "Etd",

--- a/spec/lib/rof/translators/jsonld_to_rof/accumulator_spec.rb
+++ b/spec/lib/rof/translators/jsonld_to_rof/accumulator_spec.rb
@@ -115,6 +115,40 @@ module ROF
             end
           end
         end
+
+        describe '#to_rof' do
+          let(:initial_rof) do
+            {
+              "rights"=> {
+                "edit"=>["curate_batch_user"],
+                "embargo-date"=>["2016-11-16"],
+                "read"=>["wma1"],
+                "read-groups"=>["public"]
+              }
+            }
+          end
+          context 'with one embargo-date' do
+            it 'will have a single embargo date' do
+              rof = initial_rof
+              rof['rights']['embargo-date'] = ['2016-1-2']
+              expect(described_class.new(rof).to_rof['rights'].fetch('embargo-date')).to eq('2016-1-2')
+            end
+          end
+          context 'with more than one embargo-date' do
+            it 'will raise an exception' do
+              rof = initial_rof
+              rof['rights']['embargo-date'] = ['2016-1-2', '2016-2-3']
+              expect { described_class.new(rof).to_rof }.to raise_error(described_class::TooManyEmbargoDatesError)
+            end
+          end
+          context 'no embargo-date' do
+            it 'will not have an embargo-date' do
+              rof = initial_rof
+              rof['rights'].delete('embargo-date')
+              expect { described_class.new(rof).to_rof['rights'].fetch('embargo-date') }.to raise_error(KeyError)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/lib/rof/translators/jsonld_to_rof_spec.rb
+++ b/spec/lib/rof/translators/jsonld_to_rof_spec.rb
@@ -14,6 +14,7 @@ module ROF
           output = described_class.call(jsonld_from_curatend, {})
           expect(output.size).to eq(1) # We have one item
           expect(output.first.fetch('pid')).to eq('und:pr76f190f54')
+          expect(output.first['rights'].fetch('embargo-date')).to eq("2016-11-16")
         end
       end
       describe '.call' do


### PR DESCRIPTION
Prior to this commit, the embargo-date for ROF was an array. This
commit enforces the embargo date to be a string.