### PR TITLE
Forcing cardinality of bendo-item

### DIFF
--- a/lib/rof/translators/jsonld_to_rof/accumulator.rb
+++ b/lib/rof/translators/jsonld_to_rof/accumulator.rb
@@ -71,15 +71,33 @@ module ROF
           rof
         end
 
-        class TooManyEmbargoDatesError < RuntimeError
+        class TooManyElementsError < RuntimeError
+          def initialize(context, expected_count, got_count)
+            super(%(Expected #{expected_count} in "#{context}" but instead got #{got_count}))
+          end
         end
 
         def force_cardinality_for_backwards_compatability(rof)
+          rof = force_rights_cardinality(rof)
+          rof = force_bendo_cardinality(rof)
+          rof
+        end
+
+        def force_rights_cardinality(rof)
           rights = rof.fetch('rights', {})
           if rights.key?('embargo-date')
             embargo_dates = Array.wrap(rights['embargo-date'])
-            raise TooManyEmbargoDatesError if embargo_dates.size > 1
+            raise TooManyElementsError.new('rights > embargo-date', 1, embargo_dates.size) if embargo_dates.size > 1
             rof['rights']['embargo-date'] = embargo_dates.first
+          end
+          rof
+        end
+
+        def force_bendo_cardinality(rof)
+          if rof.key?('bendo-item')
+            bendo_items = Array.wrap(rof['bendo-item'])
+            raise TooManyElementsError.new('bendo-item', 1, bendo_items.size) if bendo_items.size > 1
+            rof['bendo-item'] = bendo_items.first
           end
           rof
         end

--- a/spec/lib/rof/translators/jsonld_to_rof/accumulator_spec.rb
+++ b/spec/lib/rof/translators/jsonld_to_rof/accumulator_spec.rb
@@ -117,35 +117,65 @@ module ROF
         end
 
         describe '#to_rof' do
-          let(:initial_rof) do
-            {
-              "rights"=> {
-                "edit"=>["curate_batch_user"],
-                "embargo-date"=>["2016-11-16"],
-                "read"=>["wma1"],
-                "read-groups"=>["public"]
+          describe 'for embargo-date' do
+            let(:initial_rof) do
+              {
+                "rights"=> {
+                  "edit"=>["curate_batch_user"],
+                  "embargo-date"=>["2016-11-16"],
+                  "read"=>["wma1"],
+                  "read-groups"=>["public"]
+                }
               }
-            }
-          end
-          context 'with one embargo-date' do
-            it 'will have a single embargo date' do
-              rof = initial_rof
-              rof['rights']['embargo-date'] = ['2016-1-2']
-              expect(described_class.new(rof).to_rof['rights'].fetch('embargo-date')).to eq('2016-1-2')
+            end
+            context 'with one embargo-date' do
+              it 'will have a single embargo date' do
+                rof = initial_rof
+                rof['rights']['embargo-date'] = ['2016-1-2']
+                expect(described_class.new(rof).to_rof['rights'].fetch('embargo-date')).to eq('2016-1-2')
+              end
+            end
+            context 'with more than one embargo-date' do
+              it 'will raise an exception' do
+                rof = initial_rof
+                rof['rights']['embargo-date'] = ['2016-1-2', '2016-2-3']
+                expect { described_class.new(rof).to_rof }.to raise_error(described_class::TooManyElementsError)
+              end
+            end
+            context 'no embargo-date' do
+              it 'will not have an embargo-date' do
+                rof = initial_rof
+                rof['rights'].delete('embargo-date')
+                expect { described_class.new(rof).to_rof['rights'].fetch('embargo-date') }.to raise_error(KeyError)
+              end
             end
           end
-          context 'with more than one embargo-date' do
-            it 'will raise an exception' do
-              rof = initial_rof
-              rof['rights']['embargo-date'] = ['2016-1-2', '2016-2-3']
-              expect { described_class.new(rof).to_rof }.to raise_error(described_class::TooManyEmbargoDatesError)
+          describe 'bendo-item' do
+            let(:initial_rof) do
+              {
+                "bendo-item"=> ['abcd1']
+              }
             end
-          end
-          context 'no embargo-date' do
-            it 'will not have an embargo-date' do
-              rof = initial_rof
-              rof['rights'].delete('embargo-date')
-              expect { described_class.new(rof).to_rof['rights'].fetch('embargo-date') }.to raise_error(KeyError)
+            context 'with one embargo-date' do
+              it 'will have a single embargo date' do
+                rof = initial_rof
+                rof['bendo-item'] = ['abcd1']
+                expect(described_class.new(rof).to_rof.fetch('bendo-item')).to eq('abcd1')
+              end
+            end
+            context 'with more than one embargo-date' do
+              it 'will raise an exception' do
+                rof = initial_rof
+                rof['bendo-item'] = ['abcd1', 'efgh1']
+                expect { described_class.new(rof).to_rof }.to raise_error(described_class::TooManyElementsError)
+              end
+            end
+            context 'no embargo-date' do
+              it 'will not have an embargo-date' do
+                rof = initial_rof
+                rof.delete('bendo-item')
+                expect { described_class.new(rof).to_rof.fetch('bendo-item') }.to raise_error(KeyError)
+              end
             end
           end
         end


### PR DESCRIPTION
```console
1. Verifying und:xw42n586h2n ...error. Content for bendo-item is not a string.
/home/app/curatend-batch/shared/bundle/ruby/2.0.0/bundler/gems/rof-822f580239bd/lib/rof/ingest.rb:93:in `ingest_datastream'
	/home/app/curatend-batch/shared/bundle/ruby/2.0.0/bundler/gems/rof-822f580239bd/lib/rof/ingest.rb:77:in `block in Ingest'
```