### PR TITLE
Map more fields from jsonld to rof correctly

### DIFF
--- a/lib/rof/translators/jsonld_to_rof.rb
+++ b/lib/rof/translators/jsonld_to_rof.rb
@@ -21,8 +21,9 @@ module ROF
         handler.namespace_prefix('bibo:')
         handler.within(['metadata'])
       end
-      PredicateHandler.register('info:fedora/fedora-system:def/relations-external') do |handler|
-        handler.map('#isMemberOfCollection', to: ['rels-ext', 'isMemberOfCollection'])
+      PredicateHandler.register('info:fedora/fedora-system:def/relations-external#') do |handler|
+        handler.namespace_prefix('')
+        handler.within(['rels-ext'])
       end
       PredicateHandler.register('http://id.loc.gov/vocabulary/relators/') do |handler|
         handler.namespace_prefix('mrel:')
@@ -53,6 +54,12 @@ module ROF
         handler.map('representativeFile', multiple: false) do |object, accumulator|
           accumulator.register_properties('representative', object)
         end
+        handler.map('characterization', to: ['characterization'], multiple: false, force: true)
+        # how to discard?
+        handler.map('content') { |object, accumulator| }
+        handler.map('thumbnail') { |object, accumulator| }
+        handler.map('filename') { |object, accumulator| }
+        handler.map('mimetype') { |object, accumulator| }
       end
 
       PredicateHandler.register('http://purl.org/dc/terms/') do |handler|

--- a/lib/rof/translators/jsonld_to_rof.rb
+++ b/lib/rof/translators/jsonld_to_rof.rb
@@ -55,11 +55,12 @@ module ROF
           accumulator.register_properties('representative', object)
         end
         handler.map('characterization', to: ['characterization'], multiple: false, force: true)
-        # how to discard?
-        handler.map('content') { |object, accumulator| }
-        handler.map('thumbnail') { |object, accumulator| }
-        handler.map('filename') { |object, accumulator| }
-        handler.map('mimetype') { |object, accumulator| }
+
+        # Discard these keys when mapping from JSON-LD to ROF
+        handler.skip('content')
+        handler.skip('thumbnail')
+        handler.skip('filename')
+        handler.skip('mimetype')
       end
 
       PredicateHandler.register('http://purl.org/dc/terms/') do |handler|

--- a/lib/rof/translators/jsonld_to_rof/predicate_handler.rb
+++ b/lib/rof/translators/jsonld_to_rof/predicate_handler.rb
@@ -164,6 +164,12 @@ module ROF
             end
           end
 
+          # Skip the given slug
+          # @param [String] slug
+          def skip(slug)
+            map(slug) { |*| }
+          end
+
           # @api private
           # Responsible for coordinating the extraction of the location
           class LocationExtractor

--- a/spec/fixtures/jsonld-translation/5h73pv65x8x.jsonld
+++ b/spec/fixtures/jsonld-translation/5h73pv65x8x.jsonld
@@ -1,0 +1,81 @@
+{
+  "@context": {
+    "und": "https://curate.nd.edu/show/",
+    "bibo": "http://purl.org/ontology/bibo/",
+    "dc": "http://purl.org/dc/terms/",
+    "ebucore": "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "mrel": "http://id.loc.gov/vocabulary/relators/",
+    "nd": "https://library.nd.edu/ns/terms/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "vracore": "http://purl.org/vra/",
+    "frels": "info:fedora/fedora-system:def/relations-external#",
+    "ms": "http://www.ndltd.org/standards/metadata/etdms/1.1/",
+    "pav": "http://purl.org/pav/",
+    "fedora-model": "info:fedora/fedora-system:def/model#",
+    "hydra": "http://projecthydra.org/ns/relations#",
+    "hasModel": {
+      "@id": "fedora-model:hasModel",
+      "@type": "@id"
+    },
+    "hasEditor": {
+      "@id": "hydra:hasEditor",
+      "@type": "@id"
+    },
+    "hasEditorGroup": {
+      "@id": "hydra:hasEditorGroup",
+      "@type": "@id"
+    },
+    "hasViewer": {
+      "@id": "hydra:hasViewer",
+      "@type": "@id"
+    },
+    "hasViewerGroup": {
+      "@id": "hydra:hasViewerGroup",
+      "@type": "@id"
+    },
+    "isPartOf": {
+      "@id": "frels:isPartOf",
+      "@type": "@id"
+    },
+    "isMemberOfCollection": {
+      "@id": "frels:isMemberOfCollection",
+      "@type": "@id"
+    },
+    "isEditorOf": {
+      "@id": "hydra:isEditorOf",
+      "@type": "@id"
+    },
+    "hasMember": {
+      "@id": "frels:hasMember",
+      "@type": "@id"
+    },
+    "previousVersion": "pav:previousVersion"
+  },
+  "@id": "und:5h73pv65x8x",
+  "dc:dateSubmitted": {
+    "@value": "2017-06-26Z",
+    "@type": "http://www.w3.org/2001/XMLSchema#date"
+  },
+  "dc:modified": {
+    "@value": "2017-06-30Z",
+    "@type": "http://www.w3.org/2001/XMLSchema#date"
+  },
+  "dc:title": "v2exdfdmhs.zip",
+  "frels:isPartOf": {
+    "@id": "und:3484zg6774d"
+  },
+  "nd:accessEdit": "mcoppedg",
+  "nd:accessReadGroup": "public",
+  "nd:afmodel": "GenericFile",
+  "nd:bendoitem": "3484zg6774d",
+  "nd:characterization": "<fits xmlns=\"http://hul.harvard.edu/ois/xml/ns/fits/fits_output\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd\" version=\"0.6.2\" timestamp=\"6/26/17 5:46 PM\">\n  <identification>\n    <identity format=\"ZIP Format\" mimetype=\"application/zip\" toolname=\"FITS\" toolversion=\"0.6.2\">\n      <tool toolname=\"file utility\" toolversion=\"5.04\"/>\n      <tool toolname=\"Exiftool\" toolversion=\"9.06\"/>\n      <tool toolname=\"Droid\" toolversion=\"3.0\"/>\n      <tool toolname=\"ffident\" toolversion=\"0.2\"/>\n      <version toolname=\"file utility\" toolversion=\"5.04\">2.0</version>\n      <externalIdentifier toolname=\"Droid\" toolversion=\"3.0\" type=\"puid\">x-fmt/263</externalIdentifier>\n    </identity>\n  </identification>\n  <fileinfo>\n    <lastmodified toolname=\"Exiftool\" toolversion=\"9.06\" status=\"SINGLE_RESULT\">2017:06:26 17:45:52-04:00</lastmodified>\n    <filepath toolname=\"OIS File Information\" toolversion=\"0.1\" status=\"SINGLE_RESULT\">/tmp/und:5h73pv65x8x-content.0.zip20170626-61058-1ylrkx4.zip</filepath>\n    \n    <size toolname=\"OIS File Information\" toolversion=\"0.1\" status=\"SINGLE_RESULT\">55150864</size>\n    <md5checksum toolname=\"OIS File Information\" toolversion=\"0.1\" status=\"SINGLE_RESULT\">3c5944ded56607b19c5c0cc1fa382012</md5checksum>\n    <fslastmodified toolname=\"OIS File Information\" toolversion=\"0.1\" status=\"SINGLE_RESULT\">1498513552000</fslastmodified>\n  </fileinfo>\n  <filestatus/>\n  <metadata/>\n</fits>",
+  "nd:content": "CONTENTSHOULD_NOT_BE_IN_ROF",
+  "nd:depositor": "batch_ingest",
+  "nd:filename": "FILENAME_SHOULD_NOT_BE_IN_ROF",
+  "nd:mimetype": "MIMETYPE_SHOULD_NOT_BE_IN_ROF",
+  "nd:owner": "mcoppedg",
+  "nd:thumbnail": {
+    "@id": "THUMBNAIL_SHOULD_NOT_BE_IN_ROF"
+  }
+}

--- a/spec/lib/rof/translators/jsonld_to_rof/predicate_handler_spec.rb
+++ b/spec/lib/rof/translators/jsonld_to_rof/predicate_handler_spec.rb
@@ -12,6 +12,7 @@ module ROF
 
           described_class.register('https://library.nd.edu/ns/terms/') do |handler|
             handler.map('accessRead', to: ['rights', 'read'])
+            handler.skip('to_my_loo')
           end
           described_class.register('http://purl.org/dc/terms/') do |handler|
             handler.namespace_prefix('dc:')
@@ -51,6 +52,12 @@ module ROF
               "metadata" => { "ms:something" => [object] },
               "ms:degree" => { "another" => { "ms:somewhere" => [object] } }
             })
+          end
+
+          it 'handles skip imperative' do
+            described_class.call('https://library.nd.edu/ns/terms/accessRead', object, accumulator)
+            described_class.call('https://library.nd.edu/ns/terms/to_my_loo', object, accumulator)
+            expect(accumulator.to_rof).to eq({ "rights" => { "read" => ["my-object"] } })
           end
 
           it 'handles option without namespace' do

--- a/spec/lib/rof/translators/jsonld_to_rof_spec.rb
+++ b/spec/lib/rof/translators/jsonld_to_rof_spec.rb
@@ -68,6 +68,24 @@ module ROF
         end
       end
 
+      describe 'jsonld-translation regression verification' do
+        it 'discards content, thumbnail, filename, and mimetype' do
+          jsonld_from_curatend = JSON.load(File.read(File.join(GEM_ROOT, "spec/fixtures/jsonld-translation/5h73pv65x8x.jsonld")))
+          output = described_class.call(jsonld_from_curatend, {})
+          expect(output.size).to eq(1)
+          object = output.first
+          expect(object.fetch('characterization')).to be_a(String)
+          expect(object.fetch('characterization')).to eq(jsonld_from_curatend.fetch('nd:characterization'))
+
+          # Checking that we don't include the following keys.
+          json_doc = JSON.dump(object)
+          ['content', 'thumbnail', 'filename', 'mimetype'].each do |key|
+            value = "#{key.upcase}_SHOULD_NOT_BE_IN_ROF"
+            expect(json_doc).not_to include(value)
+          end
+        end
+      end
+
       describe '::REGEXP_FOR_A_CURATE_RDF_SUBJECT' do
         it 'handles data as expected' do
           [


### PR DESCRIPTION
Some jsonld fields only exist on GenericFile objects. Those fields were
not mapped in the jsonld-rof translator. This patch provides a mapping
for them.

The specific fields I noticed are

* `nd:characterization`
* `nd:content`
* `nd:filename`
* `nd:mimetype`
* `nd:thumbnail`
* `#isPartOf`

Comments on this approach, @jeremyf?