### PR TITLE
Locking RDF components to compatable Ruby versions

### DIFF
--- a/rof.gemspec
+++ b/rof.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rdf", "~> 2.0.1"
-  spec.add_dependency "rdf-rdfxml"
+  spec.add_dependency "rdf-rdfxml", "~> 2.0.0"
+  spec.add_dependency "rdf-aggregate-repo", "~> 2.0.0"
   # constrain rdf-turtle since the newer version wants rdf 2.2
   spec.add_dependency "rdf-turtle", '~> 2.0.0'
   spec.add_dependency "rdf-isomorphic"


### PR DESCRIPTION
In looking at the following repository gemspecs, the allowed version is
Ruby 2.0 or greater. The allowed version changes from 2.0 to 2.2 after
each gem hits version 2.1.x

The gemspecs are:

* https://github.com/ruby-rdf/rdf-rdfxml/blob/2.0.0/rdf-rdfxml.gemspec
* https://github.com/ruby-rdf/rdf-aggregate-repo/blob/2.0.0/rdf-aggregate-repo.gemspec