### PR TITLE
Adding multi-version support for ActiveSupport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,22 @@
 language: ruby
 rvm:
-  - "2.0.0-p648"
+  - "2.0.0"
   - "2.1.10"
-  - "2.2.6"
-  - "2.3.3"
-  - "2.4.0"
+  - "2.2.8"
+  - "2.3.5"
+  - "2.4.2"
+cache: bundler
+sudo: false
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 matrix:
-  allow_failures:
-    - rvm: "2.3.3"
-    - rvm: "2.2.6"
-    - rvm: "2.4.0"
-
-script: "bundle exec rake"
-
-notifications:
-  irc: "irc.freenode.org#ndlib"
-
-before_install:
-  - gem install bundler
-
-sudo: false
-cache: bundler
+  exclude:
+  - rvm: 2.0.0
+    gemfile: gemfiles/activesupport5.gemfile
+  - rvm: 2.1.10
+    gemfile: gemfiles/activesupport5.gemfile
+gemfile:
+  - gemfiles/activesupport5.gemfile
+  - gemfiles/activesupport4.gemfile

--- a/gemfiles/activesupport4.gemfile
+++ b/gemfiles/activesupport4.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in rof.gemspec
+gemspec path: '../'
+gem 'activesupport', '~> 4.0'

--- a/gemfiles/activesupport5.gemfile
+++ b/gemfiles/activesupport5.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in rof.gemspec
+gemspec path: '../'
+gem 'activesupport', '~> 5.0'

--- a/rof.gemspec
+++ b/rof.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '~> 1.6.8.1' # Need this version for older rubies
   # only needed because we use ruby < 2.2.2 in production and that doesn't play
   # nice with rails 5
-  spec.add_dependency 'activesupport', '< 5.0'
+  spec.add_dependency "activesupport", '>= 4.0', "< 6.0"
   spec.add_dependency 'ebnf', '< 1.0.2'
   # adding this only because bundler selects version 2.1 and it breaks things
   spec.add_dependency 'rdf-xsd', '~> 2.0.0'


### PR DESCRIPTION
## Adding multi-version support for ActiveSupport

c308797b03048413146f40f3d86373c66e66560b

Following on the changes to Locabulary to allow for multiple version
(see ndlib/locabulary@4bd0f59), I want to enable different versions
of ActiveSupport.

Using the following documentation:

* [Travis for multiple versions of dependency][travis_multiple_versions_doc]
* [Travis for custom build matrix][travis_build_matrix]
* [Bundler][bundler_doc]

Travis for mutliple versions:

> To test against multiple versions of dependencies:
>
> 1. Create a directory in your project’s repository root where you will
>    keep gemfiles, such as ./gemfiles.
> 2. Add one or more gemfiles to it.
> 3. Set the the gemfile key in your .travis.yml.
>
> Thoughtbot’s Paperclip is tested against multiple ActiveRecord versions:
>
> ```yml
> gemfile:
>   - gemfiles/rails2.gemfile
>   - gemfiles/rails3.gemfile
>   - gemfiles/rails3_1.gemfile
> ```

Travis for custom build matrix:

> You can also define exclusions to the build matrix:
>
> ```yml
> matrix:
>   exclude:
>   - rvm: 1.9.3
>     gemfile: gemfiles/Gemfile.rails-2.3.x
>     env: ISOLATED=true
>   - rvm: jruby
>     gemfile: gemfiles/Gemfile.rails-2.3.x
>     env: ISOLATED=true
> ```

Bundler:

> As well, you can point to a specific gemspec using :path. If your
> gemspec is in /gemspec/path, use
> `gemspec :path => '/gemspec/path'`

[travis_multiple_versions_doc]:https://docs.travis-ci.com/user/languages/ruby/#Testing-against-multiple-versions-of-dependencies
[travis_build_matrix]:https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix
[bundler_doc]:http://bundler.io/rubygems.html
