### PR TITLE
Updating RDF and other dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/gemfiles/*.lock

--- a/rof.gemspec
+++ b/rof.gemspec
@@ -20,26 +20,36 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rdf", "~> 2.0.1"
-  spec.add_dependency "rdf-rdfxml", "~> 2.0.0"
-  spec.add_dependency "rdf-aggregate-repo", "~> 2.0.0"
-  # constrain rdf-turtle since the newer version wants rdf 2.2
-  spec.add_dependency "rdf-turtle", '~> 2.0.0'
-  spec.add_dependency 'rdf-rdfa', '~>2.0.1'
-  spec.add_dependency "rdf-isomorphic", "~> 2.0.0"
-  spec.add_dependency "json-ld", "~> 2.0.0"
-  spec.add_dependency "mime-types", "~> 2.4"
+  # Ruby 2.1 and below require the following
+  if RUBY_VERSION =~ /\A2\.[0|1]/
+    spec.add_dependency "rdf", "~> 2.0.1"
+    spec.add_dependency "rdf-rdfxml", "~> 2.0.0"
+    spec.add_dependency "rdf-aggregate-repo", "~> 2.0.0"
+    spec.add_dependency "rdf-turtle", '~> 2.0.0'
+    spec.add_dependency 'rdf-rdfa', '~>2.0.1'
+    spec.add_dependency "rdf-isomorphic", "~> 2.0.0"
+    spec.add_dependency "json-ld", "~> 2.0.0"
+    spec.add_dependency 'ebnf', '< 1.0.2'
+    spec.add_dependency 'rdf-xsd', '~> 2.0.0'
+  # Aim for at least Ruby 2.2.8
+  else
+    spec.add_dependency "rdf"
+    spec.add_dependency "rdf-rdfxml"
+    spec.add_dependency "rdf-aggregate-repo"
+    spec.add_dependency "rdf-turtle"
+    spec.add_dependency 'rdf-rdfa'
+    spec.add_dependency "rdf-isomorphic"
+    spec.add_dependency "json-ld"
+    spec.add_dependency 'ebnf'
+    spec.add_dependency 'rdf-xsd'
+  end
+
+  spec.add_dependency "mime-types"
   spec.add_dependency "rubydora", "~> 1.8.1"
   spec.add_dependency "noids_client"
   spec.add_dependency "rsolr", "~> 1.1.2"
   spec.add_dependency 'deprecation', '~> 0.1'
-  spec.add_dependency 'nokogiri', '~> 1.6.8.1' # Need this version for older rubies
-  # only needed because we use ruby < 2.2.2 in production and that doesn't play
-  # nice with rails 5
-  spec.add_dependency "activesupport", '>= 4.0', "< 6.0"
-  spec.add_dependency 'ebnf', '< 1.0.2'
-  # adding this only because bundler selects version 2.1 and it breaks things
-  spec.add_dependency 'rdf-xsd', '~> 2.0.0'
+  spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "codeclimate-test-reporter"


### PR DESCRIPTION
## Updating RDF and other dependencies

f0922a0f6be375dc6e08e232b0003031bae56c32

Expanding the gem to allow for Ruby 2.2 developments in
upstream utilization. This work builds on steps taken in
[locabulary][1]

The local testing involved tweaking the `.ruby-version` and running
the corresponding:

```console
$ BUNDLE_GEMFILE=gemfiles/activesupport4.gemfile bundle update
$ BUNDLE_GEMFILE=gemfiles/activesupport4.gemfile bundle exec rake
```

Once those tests were completed, I restored and rearranged the
gemspec to account for differing ruby versions

[1]: https://github.com/ndlib/locabulary/pull/56
