### PR TITLE
Remove deprecated code climate gem

### DIFF
--- a/rof.gemspec
+++ b/rof.gemspec
@@ -52,7 +52,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "fasterer"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -4,10 +4,9 @@
 if ENV['COV'] || ENV['COVERAGE'] || ENV['TRAVIS']
   if ENV['TRAVIS']
     require 'simplecov'
-    require "codeclimate-test-reporter"
     SimpleCov.start do
       formatter(
-        SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter, CodeClimate::TestReporter::Formatter])
+        SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter])
       )
     end
   elsif ENV['COV'] || ENV['COVERAGE']


### PR DESCRIPTION
The gem codeclimate-test-formatter is deprecated, and errors out when
running in ruby < 2.2. This removes the gem.