### PR TITLE
Add ROF-to-CSV translator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,16 +28,15 @@ namespace :commitment do
   task :code_coverage do
     require 'json'
     # Our goal is to stay at this coverage level or higher; As the level increases, we bump up the goal
-    # Added the conditional for Travis and RUBY_VERSION because something is weird upstream
-    COVERAGE_GOAL = ENV['TRAVIS'] && RUBY_VERSION =~ /\A2\.[01]/ ? 90 : 95
+    COVERAGE_GOAL = 95
     $stdout.puts "Checking code_coverage"
     lastrun_filename = File.expand_path('../coverage/.last_run.json', __FILE__)
     if File.exist?(lastrun_filename)
       coverage_percentage = JSON.parse(File.read(lastrun_filename)).fetch('result').fetch('covered_percent').to_i
+      $stdout.puts "\t#{COVERAGE_GOAL}%\tExpected\n"
+      $stdout.puts "\t#{coverage_percentage}%\tActual\n"
       if coverage_percentage < COVERAGE_GOAL
-        abort("ERROR: Code Coverage Goal Not Met:\n\t#{coverage_percentage}%\tExpected\n\t#{COVERAGE_GOAL}%\tActual")
-      else
-        $stdout.puts "Code Coverage Goal Met (#{COVERAGE_GOAL}%)"
+        abort("ERROR: Code Coverage Goal Not Met")
       end
     else
       abort "Expected #{lastrun_filename} to exist for code coverage"

--- a/bin/rof_to_csv
+++ b/bin/rof_to_csv
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby -Ilib
+
+require 'rof'
+require 'optparse'
+require 'json'
+
+opt = OptionParser.new do |opts|
+  opts.banner = %q{Usage: rof_to_csv
+  Reads a ROF file from stdin.
+  Writes a CSV file to stdout.
+
+  In case of an error, a message is written to stderr and the program
+  exits with a non-zero status.
+}
+end
+
+opt.parse!
+
+if ARGV.length != 0
+  abort opt.help
+end
+
+STDIN.set_encoding("UTF-8")
+file_contents = STDIN.read
+rof = JSON.parse(file_contents)
+ROF::CLI.rof_to_csv(rof, {}, STDOUT)

--- a/lib/rof/cli.rb
+++ b/lib/rof/cli.rb
@@ -110,6 +110,13 @@ module ROF
       end
     end
 
+    def self.rof_to_csv(items, config = {}, outfile = STDOUT)
+      result = ROF::Translators::RofToCsv.call(items, config)
+      with_outfile_handling(outfile) do |writer|
+        writer.write(result)
+      end
+    end
+
     # Convert the given JSON-LD to ROF JSON document
     # @param [Hash] jsonld - contents of a CSV file
     # @param [Hash] config

--- a/lib/rof/filters/work.rb
+++ b/lib/rof/filters/work.rb
@@ -40,7 +40,7 @@ module ROF
 
       # make the first file be the representative thumbnail
       def make_thumbnail(result, main_obj, input_obj)
-        thumb_rep = nil
+        thumb_rep = input_obj['representative']  # might be nil
         input_obj['files'].each do |finfo|
           if finfo.is_a?(String)
             fname = finfo
@@ -101,7 +101,7 @@ module ROF
         result['pid'] = input_obj.fetch('pid', @utility.next_label)
         result['bendo-item'] = input_obj['bendo-item']
         result['rights'] = input_obj['rights']
-        result['properties'] = ROF::Utility.prop_ds(input_obj['owner'])
+        result['properties'] = ROF::Utility.prop_ds(input_obj['owner'], input_obj['representative'])
         result['properties-meta'] = { 'mime-type' => 'text/xml' }
         result['rels-ext'] = input_obj.fetch('rels-ext', {})
         result['metadata'] = input_obj['metadata']

--- a/lib/rof/translators/rof_to_csv.rb
+++ b/lib/rof/translators/rof_to_csv.rb
@@ -1,0 +1,112 @@
+require 'rof/translator'
+require 'csv'
+require 'json'
+
+module ROF::Translators
+  # translate a ROF file into a CSV file
+  #
+  # The goal is to create a perfect mapping from csv ==> rof ==> csv.
+  # We will modify the csv conventions as needed to get this to happen.
+  #
+  # We expect this to be called on rof files already generated from csv_to_rof. but that may not
+  # be the case, so the code below tries to handle the general case as much as possible. With that
+  # said, our aim is just handling the ROF files that have the curatend object model. (Since ROF objects
+  # can encode arbitrary fedora 3 objects, which have just too much variety).
+  #
+  # Returns the contents of the csv file as a string
+  class RofToCsv < ROF::Translator
+    def self.call(input_rof, config = {})
+      # we first scan the rof and turn each rof object into a single-level map of column-name --> value
+      seen_names = []
+      add_field = lambda do |itm, col, val|
+        return if val.nil?
+        seen_names << col unless seen_names.include?(col)
+        itm[col] = val
+      end
+      results = []
+      input_rof.each do |item|
+        v = {}
+        add_field.call(v, 'pid', item['pid'])
+        add_field.call(v, 'rof-type', item['type'])
+        add_field.call(v, 'af-model', item['af-model'])
+        add_field.call(v, 'bendo-item', item['bendo-item'])
+        add_field.call(v, 'access', decode_rights(item))
+
+        item['rels-ext']&.each do |predicate, value|
+          next if predicate == "hasModel"
+          next if predicate == "@context"
+          value = value.join('|') if value.is_a?(Array)
+          add_field.call(v, predicate, value)
+        end
+
+        props = ROF::Utility.prop_ds_to_values(item['properties'])
+        add_field.call(v, 'owner', props[:owner])
+        add_field.call(v, 'representative', props[:representative])
+        m = item['content-meta']
+        if m
+          add_field.call(v, 'file-URL', m['URL'])
+          add_field.call(v, 'file-mime-type', m['mime-type'])
+          add_field.call(v, 'filename', m['label'])
+          # need to recover the path structure from the bendo url so we can find the file
+          # in the local directory. Should this be a field if it can be derived from another one?
+          if m['URL']
+            add_field.call(v, 'file-with-path', m['URL'].sub(%r{.*/item/\w+/}, ''))
+          end
+        end
+
+        item['metadata']&.each do |predicate, value|
+          next if predicate == "@context"
+          value = value.join('|') if value.is_a?(Array)
+          add_field.call(v, predicate, value)
+        end
+
+        results.push(v)
+      end
+
+      # Output the rows as a csv. Do this last since we need to know all of the
+      # column names at the beginning. While we don't do this at the moment, the
+      # column names could be reordered to some cannonical ordering.
+      #
+      # Returns a string containing the contents of the CSV file.
+      CSV.generate do |csv|
+        csv << seen_names
+        results.each do |v|
+          csv << seen_names.map { |name| v[name] }
+        end
+      end
+    end
+
+    # try to decode the rights by looking at the rels-ext and the rights metadata
+    def self.decode_rights(item)
+      # first move any relevant rels-ext links back to the rights
+      rights = {}
+      if item['rels-ext']
+        r = item['rels-ext']
+        rights['read'] = r.delete('hasViewer')
+        rights['read-groups'] = r.delete('hasViewerGroup')
+        rights['edit'] = r.delete('hasEditor')
+        rights['edit-groups'] = r.delete('hasEditorGroup')
+        rights.delete_if {|k,v| v.nil? || v.empty?}
+      end
+
+      # now merge in anything in the rights block
+      if item['rights']
+        r = item['rights']
+        extend_entry = lambda do |field, value|
+          rights[field] = rights.fetch(field, []).concat(Array(value)).uniq
+        end
+
+        extend_entry.call('discover', r['discover'])
+        extend_entry.call('discover-groups', r['discover-groups'])
+        extend_entry.call('read', r['read'])
+        extend_entry.call('read-groups', r['read-groups'])
+        extend_entry.call('edit', r['edit'])
+        extend_entry.call('edit-groups', r['edit-groups'])
+        rights['embargo-date'] = r['embargo-date']
+        rights.delete_if {|k,v| v.nil? || v.empty?}
+      end
+
+      ROF::Access.encode(rights)
+    end
+  end
+end

--- a/lib/rof/utility.rb
+++ b/lib/rof/utility.rb
@@ -58,6 +58,16 @@ module ROF
       s += "</fields>\n"
       s
     end
+    
+    def self.prop_ds_to_values(ds_value)
+      owner = nil
+      representative = nil
+      m = ds_value.match(/<owner>(.*)<\/owner>/)
+      owner = m[1] if m
+      m = ds_value.match(/<representative>(.*)<\/representative>/)
+      representative = m[1] if m
+      { owner: owner, representative: representative }        
+    end
 
     # test for embargo xml cases
     def self.has_embargo_date?(embargo_xml)

--- a/spec/lib/rof/translators/csv_to_rof_spec.rb
+++ b/spec/lib/rof/translators/csv_to_rof_spec.rb
@@ -2,17 +2,6 @@ require 'spec_helper'
 
 module ROF::Translators
   describe "translate CSV" do
-    it "requires the columns type and owner" do
-      s = "dc:title,access,owner"
-      expect{CsvToRof.call(s)}.to raise_error(ROF::Translators::CsvToRof::MissingOwnerOrType)
-
-      s = "dc:title,access,type"
-      expect{CsvToRof.call(s)}.to raise_error(ROF::Translators::CsvToRof::MissingOwnerOrType)
-
-      s = "dc:title,type,owner,access"
-      expect(CsvToRof.call(s)).to eq([])
-    end
-
     it "requires rows to have an owner and type" do
       s = %q{type,owner
       Work,

--- a/spec/lib/rof/translators/rof_to_csv_spec.rb
+++ b/spec/lib/rof/translators/rof_to_csv_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module ROF::Translators
+  describe "translate ROF" do
+    it "pulls rights from both rels-ext and rights fields" do
+      input = {
+        "rels-ext" => {
+          "hasViewerGroup" => ["und:0", "und:1"]
+        },
+        "rights" => {
+          "read-groups" => ["some_people"],
+          "edit" => ["jdoe"]
+        }
+      }
+      rights = RofToCsv.decode_rights(input)
+      expect(rights).to eq("readgroup=und:0,und:1,some_people;edit=jdoe")
+    end
+    
+    it "decodes rof into correct fields" do
+    input = {
+        "pid" => "temp:01",
+        "type" => "fobject",
+        "bendo-item" => "0123456789",
+        "af-model" => "GenericFile",
+        "properties" => "<properties><owner>jdoe</owner></properties>",
+        "rels-ext" => { "hasModel" => "GenericFile", "@context" => {}, "hasEditorGroup" => ["temp:02"], "isPartOf" => ["temp:03"] },
+        "rights" => {"read-groups" => "public", "edit" => "jdoe" },
+        "content-meta" => {"URL" => "bendo:/item/01/some_file/here.pdf", "mime-type" => "text/json", "label" => "here.pdf"},
+        "metadata" => {"@context" => {}, "dc:title" => "here" }
+      }
+      result = RofToCsv.call([input])
+      expect(result).to eq(%q{pid,rof-type,af-model,bendo-item,access,isPartOf,owner,file-URL,file-mime-type,filename,file-with-path,dc:title
+temp:01,fobject,GenericFile,0123456789,editgroup=temp:02;readgroup=public;edit=jdoe,temp:03,jdoe,bendo:/item/01/some_file/here.pdf,text/json,here.pdf,some_file/here.pdf,here
+} )
+    end
+  end
+end

--- a/spec/lib/rof/utility_spec.rb
+++ b/spec/lib/rof/utility_spec.rb
@@ -15,6 +15,17 @@ module ROF
         it { is_expected.to eq "<fields><depositor>batch_ingest</depositor>\n<owner>msuhovec</owner>\n</fields>\n" }
       end
     end
+    
+    describe 'prop_ds_to_value' do
+      context 'decode properties datastream' do
+        subject { described_class.prop_ds_to_values("<fields><depositor>batch_ingest</depositor>\n<owner>msuhovec</owner>\n<representative>temp:1234</representative>\n</fields>\n") }
+        it { is_expected.to eq({ owner: "msuhovec", representative: "temp:1234"}) }
+      end
+      context 'decode without representative' do
+        subject { described_class.prop_ds_to_values("<fields><depositor>batch_ingest</depositor>\n<owner>msuhovec</owner>\n</fields>\n") }
+        it { is_expected.to eq({ owner: "msuhovec", representative: nil}) }
+      end
+    end
     describe 'next_label' do
        let(:id) { util.next_label}
 


### PR DESCRIPTION
The goal is to capture enough information so that curate ROF files can
be fathaifully translated back and forth from ROF to CSV. (ROF files can
model arbitrary fedora 3 objects, so doing the translation in general
would be much-much more difficult). The translation will make updates
easier since it lets people make them directly in a CSV file that will
faithfully be turned back into the corresponding ROF file. It also
solves the problem that there is no spreadsheet giving the PID assigned
to each item. As a side-effect, we resolve ticket DLTP-1605, "CurateND
Batch CSV Thumbnail", albeit the column is named "representative".

* Adds command line tool `rof_to_csv`
* Adds CSV column names for `rof-type` (synonymous with, but less
  confusing than the column name `type`.)
* Add column names for `representative`, `file-URL`, `file-mime-type`,
 `filename`, `file-with-path`.
* Decodes rights by looking at both rightsMetadata and RELS-EXT.
* Removed test for columns named type and owner, since now `rof-type` is
  also allowed.
* Revised some of the code coverage checks since we don't need to
  account for ruby 2.1 anymore.

Fixes DLTP-1605