### PR TITLE
Refactor work filter

### DIFF
--- a/bin/rof
+++ b/bin/rof
@@ -55,7 +55,7 @@ when "ingest", "validate"
 when "filter"
   filter_name = ARGV[1]
   file_name = ARGV[2]
-  filter = ROF::Filters.for(filter_name, file_name: file_name, bendo_info: bendo_info, prefix: prefix, noids: noids)
+  filter = ROF::Filters.for(filter_name, bendo_info: bendo_info, prefix: prefix, noids: noids)
   ROF::CLI.filter_file(filter, file_name, STDOUT)
 else
   STDERR.puts "Unknown command #{ARGV[0]}"

--- a/lib/rof/filters/filename_normalize.rb
+++ b/lib/rof/filters/filename_normalize.rb
@@ -5,23 +5,20 @@ module ROF
   module Filters
     # Make Filename and its label URL-legal
     class FilenameNormalize < ROF::Filter
-      def initialize(options = {})
-      end
+      def initialize(_options = {}); end
 
       # Adjust the content labels and URL of all items in the obj_list.
       # If move_files is true, then also try to rename the files in the filesystem.
-      def process(obj_list, move_files=true)
+      def process(obj_list, move_files = true)
         nerr = 0
         # We need to map access with pid to rels-ext predicates
         obj_list.map! do |obj|
           content_meta = obj.fetch('content-meta', nil)
           next obj if content_meta.nil?
           label = content_meta.fetch('label', nil)
-          if !label.nil?
-            content_meta['label'] = make_url_friendly(label)
-          end
+          content_meta['label'] = make_url_friendly(label) unless label.nil?
           url = content_meta.fetch('URL', nil)
-          if !url.nil?
+          unless url.nil?
             old_name = File.basename(url)
             new_name = make_url_friendly(old_name)
             content_meta['URL'] = File.join(File.dirname(url), new_name)
@@ -38,9 +35,7 @@ module ROF
           end
           obj
         end
-        if nerr > 0
-          raise "Problem Renaming Files"
-        end
+        raise 'Problem Renaming Files' if nerr > 0
         obj_list
       end
 

--- a/lib/rof/filters/work.rb
+++ b/lib/rof/filters/work.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mime-types'
 require 'rof/filter'
 module ROF
@@ -28,81 +30,63 @@ module ROF
         model = decode_work_type(input_obj)
         return [input_obj] if model.nil?
 
-        main_obj = set_main_obj(input_obj, model)
+        main_obj = input_to_rof(input_obj, model)
 
-        result = [main_obj]
-        result = make_thumbnail(result, main_obj, input_obj) unless input_obj['files'].nil?
-        result
-      end
-
-      # make the first file be the representative thumbnail
-      def make_thumbnail(result, main_obj, input_obj)
+        # make the first file be the representative thumbnail
         thumb_rep = input_obj['representative'] # might be nil
-        input_obj['files'].each do |finfo|
-          if finfo.is_a?(String)
-            fname = finfo
-            finfo = { 'files' => [fname] }
-          else
-            fname = finfo['files'].first
-            raise NoFile if fname.nil?
-          end
-          finfo['rights'] ||= input_obj['rights']
-          finfo['owner'] ||= input_obj['owner']
-          finfo['bendo-item'] ||= input_obj['bendo-item']
-          finfo['metadata'] ||= {
-            '@context' => ROF::RdfContext
-          }
-          finfo['metadata']['dc:title'] ||= fname
-          mimetype = MIME::Types.of(fname)
-          mimetype = mimetype.empty? ? 'application/octet-stream' : mimetype.first.content_type
-          f_obj = {
-            'type' => 'fobject',
-            'af-model' => 'GenericFile',
-            'pid' => finfo['pid'],
-            'bendo-item' => finfo['bendo-item'],
-            'rights' => finfo['rights'],
-            'properties' => ROF::Utility.prop_ds(finfo['owner']),
-            'properties-meta' => {
-              'mime-type' => 'text/xml'
-            },
-            'rels-ext' => {
-              'isPartOf' => [main_obj['pid']]
-            },
-            'content-file' => fname,
-            'content-meta' => {
-              'label' => fname,
-              'mime-type' => mimetype
-            },
-            'collections' => finfo['collections'],
-            'metadata' => finfo['metadata']
-          }
-          f_obj.delete_if { |_k, v| v.nil? }
+        result = [main_obj]
+        input_obj['files']&.each do |finfo|
+          file_rof = make_file_rof(finfo, main_obj['pid'], input_obj)
           if thumb_rep.nil?
-            thumb_rep = f_obj['pid']
-            if thumb_rep.nil?
-              thumb_rep = next_label
-              f_obj['pid'] = thumb_rep
-            end
+            thumb_rep = file_rof['pid']
             main_obj['properties'] = ROF::Utility.prop_ds(input_obj['owner'], thumb_rep)
           end
-          result << f_obj
+          result << file_rof
         end
         result
       end
 
-      def set_main_obj(input_obj, model)
-        result = {}
+      def make_file_rof(finfo, main_pid, input_obj)
+        if finfo.is_a?(String)
+          fname = finfo
+          finfo = { 'files' => [fname] }
+        else
+          fname = finfo['files'].first
+          raise NoFile if fname.nil?
+        end
+        finfo['rights'] ||= input_obj['rights']
+        finfo['owner'] ||= input_obj['owner']
+        finfo['bendo-item'] ||= input_obj['bendo-item']
+        finfo['metadata'] ||= {
+          '@context' => ROF::RdfContext
+        }
+        finfo['metadata']['dc:title'] ||= fname
+        finfo['representative'] = nil
+        finfo['rels-ext'] = { 'isPartOf' => [main_pid] }
+        f_obj = input_to_rof(finfo, 'GenericFile')
+        f_obj['content-file'] = fname
+        mimetype = MIME::Types.of(fname)&.first&.content_type || 'application/octet-stream'
+        f_obj['content-meta'] = {
+          'label' => fname,
+          'mime-type' => mimetype
+        }
+        f_obj['collections'] = finfo['collections']
+        f_obj.delete_if { |_k, v| v.nil? }
+        f_obj
+      end
 
-        result['type'] = 'fobject'
-        result['af-model'] = model
-        result['pid'] = input_obj.fetch('pid', next_label)
-        result['bendo-item'] = input_obj['bendo-item']
-        result['rights'] = input_obj['rights']
-        result['properties'] = ROF::Utility.prop_ds(input_obj['owner'], input_obj['representative'])
-        result['properties-meta'] = { 'mime-type' => 'text/xml' }
-        result['rels-ext'] = input_obj.fetch('rels-ext', {})
-        result['metadata'] = input_obj['metadata']
-        result
+      def input_to_rof(input_obj, model)
+        {
+          'type' => 'fobject',
+          'af-model' => model,
+          'pid' => input_obj.fetch('pid') { next_label }, # only make label if needed
+          'bendo-item' => input_obj['bendo-item'],
+          'rights' => input_obj['rights'],
+          'properties' => ROF::Utility.prop_ds(input_obj['owner'], input_obj['representative']),
+          'properties-meta' => { 'mime-type' => 'text/xml' },
+          'rels-ext' => input_obj.fetch('rels-ext', {}),
+          'metadata' => input_obj['metadata']
+        }
       end
 
       # Issue pid label
@@ -110,7 +94,7 @@ module ROF
         "$(pid--#{@seq})".tap { |_| @seq += 1 }
       end
 
-      WORK_TYPE_WITH_PREFIX_PATTERN = /^[Ww]ork(-(.+))?/
+      WORK_TYPE_WITH_PREFIX_PATTERN = /^[Ww]ork(-(.+))?/.freeze
 
       WORK_TYPES = {
         # csv name => af-model
@@ -127,6 +111,7 @@ module ROF
       def decode_work_type(obj)
         if obj['type'] =~ WORK_TYPE_WITH_PREFIX_PATTERN
           return 'GenericWork' if Regexp.last_match(2).nil?
+
           Regexp.last_match(2)
         else
           # this will return nil if key t does not exist

--- a/spec/lib/rof/filters/work_spec.rb
+++ b/spec/lib/rof/filters/work_spec.rb
@@ -4,10 +4,10 @@ require 'support/an_rof_filter'
 module ROF
   module Filters
     describe Work do
-      it_behaves_like "an ROF::Filter"
-      let(:valid_options) { { file_name: '' } }
-      it "handles variant work types" do
-        w = Work.new(valid_options)
+      it_behaves_like 'an ROF::Filter'
+      let(:valid_options) { {} }
+      it 'handles variant work types' do
+        w = Work.new
 
         item = {"type" => "Work", "owner" => "user1"}
         after = w.process_one_work(item)
@@ -35,7 +35,7 @@ module ROF
       end
 
       it "makes the first file be the representative" do
-        w = Work.new(valid_options)
+        w = Work.new
 
         item = {"type" => "Work", "owner" => "user1", "files" => ["a.txt", "b.jpeg"]}
         after = w.process_one_work(item)
@@ -53,7 +53,7 @@ module ROF
       end
 
       it "decodes files correctly" do
-        w = Work.new(valid_options)
+        w = Work.new
 
         item = {
           "type" => "Work",
@@ -84,6 +84,26 @@ module ROF
         expect(after[2]).to include("type" => "fobject",
                                     "af-model" => "GenericFile",
                                     "content-file" => "extra file.txt")
+    describe 'decode_work_type' do
+      [{ input: 'article', output: 'Article' },
+       { input: 'dataset', output: 'Dataset' },
+       { input: 'document', output: 'Document' },
+       { input: 'etd', output: 'Etd' },
+       { input: 'ETD', output: 'Etd' },
+       { input: 'image', output: 'Image' }].each do |t|
+        it 'decode ' + t[:input] do
+          w = Work.new
+          result = w.decode_work_type('type' => t[:input])
+          expect(result).to eq(t[:output])
+        end
+      end
+    end
+
+    describe 'next_label' do
+      it 'assigns initial label' do
+        w = Work.new
+        id = w.next_label
+        expect(id).to eq '$(pid--0)'
       end
     end
   end

--- a/spec/lib/rof/filters/work_spec.rb
+++ b/spec/lib/rof/filters/work_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/an_rof_filter'
 
@@ -9,81 +11,86 @@ module ROF
       it 'handles variant work types' do
         w = Work.new
 
-        item = {"type" => "Work", "owner" => "user1"}
+        item = { 'type' => 'Work', 'owner' => 'user1' }
         after = w.process_one_work(item)
-        expect(after.first).to include("type" => "fobject", "af-model" => "GenericWork")
+        expect(after.first).to include('type' => 'fobject', 'af-model' => 'GenericWork')
 
-        item = {"type" => "Work-Image", "owner" => "user1"}
+        item = { 'type' => 'Work-Image', 'owner' => 'user1' }
         after = w.process_one_work(item)
-        expect(after.first).to include("type" => "fobject", "af-model" => "Image")
+        expect(after.first).to include('type' => 'fobject', 'af-model' => 'Image')
 
-        item = {"type" => "work-image", "owner" => "user1"}
+        item = { 'type' => 'work-image', 'owner' => 'user1' }
         after = w.process_one_work(item)
-        expect(after.first).to include("type" => "fobject", "af-model" => "image")
+        expect(after.first).to include('type' => 'fobject', 'af-model' => 'image')
 
-        item = {"type" => "Image", "owner" => "user1"}
+        item = { 'type' => 'Image', 'owner' => 'user1' }
         after = w.process_one_work(item)
-        expect(after.first).to include("type" => "fobject", "af-model" => "Image")
+        expect(after.first).to include('type' => 'fobject', 'af-model' => 'Image')
 
-        item = {"type" => "image", "owner" => "user1"}
+        item = { 'type' => 'image', 'owner' => 'user1' }
         after = w.process_one_work(item)
-        expect(after.first).to include("type" => "fobject", "af-model" => "Image")
+        expect(after.first).to include('type' => 'fobject', 'af-model' => 'Image')
 
-        item = {"type" => "Other", "owner" => "user1"}
+        item = { 'type' => 'Other', 'owner' => 'user1' }
         after = w.process_one_work(item)
         expect(after.first).to eq(item)
       end
 
-      it "makes the first file be the representative" do
+      it 'makes the first file be the representative' do
         w = Work.new
 
-        item = {"type" => "Work", "owner" => "user1", "files" => ["a.txt", "b.jpeg"]}
+        item = { 'type' => 'Work', 'owner' => 'user1', 'files' => ['a.txt', 'b.jpeg'] }
         after = w.process_one_work(item)
         expect(after.length).to eq(3)
-        expect(after[0]).to include("type" => "fobject",
-                                    "af-model" => "GenericWork",
-                                    "pid" => "$(pid--0)",
-                                    "properties" => ROF::Utility.prop_ds("user1", "$(pid--1)"))
-        expect(after[1]).to include("type" => "fobject",
-                                    "af-model" => "GenericFile",
-                                    "pid" => "$(pid--1)")
-        expect(after[2]).to include("type" => "fobject",
-                                    "af-model" => "GenericFile")
-        expect(after[2]["metadata"]).to include("dc:title" => "b.jpeg")
+        expect(after[0]).to include('type' => 'fobject',
+                                    'af-model' => 'GenericWork',
+                                    'pid' => '$(pid--0)',
+                                    'properties' => ROF::Utility.prop_ds('user1', '$(pid--1)'))
+        expect(after[1]).to include('type' => 'fobject',
+                                    'af-model' => 'GenericFile',
+                                    'pid' => '$(pid--1)')
+        expect(after[2]).to include('type' => 'fobject',
+                                    'af-model' => 'GenericFile')
+        expect(after[2]['metadata']).to include('dc:title' => 'b.jpeg')
       end
 
-      it "decodes files correctly" do
+      it 'decodes files correctly' do
         w = Work.new
 
         item = {
-          "type" => "Work",
-          "owner" => "user1",
-          "rights" => {"edit" => ["user1"]},
-          "metadata" => {
-            "@context" => RdfContext,
-            "dc:title" => "Q, A Letter"},
-            "files" => [
-              "thumb",
-              {
-                "type"  => "+",
-                "owner" => "user1",
-                "files" => ["extra file.txt"],
-                "rights" => {"edit" => ["user1"]}
-              }]
+          'type' => 'Work',
+          'owner' => 'user1',
+          'rights' => { 'edit' => ['user1'] },
+          'metadata' => {
+            '@context' => RdfContext,
+            'dc:title' => 'Q, A Letter'
+          },
+          'files' => [
+            'thumb',
+            {
+              'type' => '+',
+              'owner' => 'user1',
+              'files' => ['extra file.txt'],
+              'rights' => { 'edit' => ['user1'] }
+            }
+          ]
         }
         after = w.process_one_work(item)
         expect(after.length).to eq(3)
-        expect(after[0]).to include("type" => "fobject",
-                                    "af-model" => "GenericWork",
-				    "rels-ext" => {},
-                                    "pid" => "$(pid--0)")
-        expect(after[1]).to include("type" => "fobject",
-                                    "af-model" => "GenericFile",
-                                    "pid" => "$(pid--1)",
-                                    "content-file" => "thumb")
-        expect(after[2]).to include("type" => "fobject",
-                                    "af-model" => "GenericFile",
-                                    "content-file" => "extra file.txt")
+        expect(after[0]).to include('type' => 'fobject',
+                                    'af-model' => 'GenericWork',
+                                    'rels-ext' => {},
+                                    'pid' => '$(pid--0)')
+        expect(after[1]).to include('type' => 'fobject',
+                                    'af-model' => 'GenericFile',
+                                    'pid' => '$(pid--1)',
+                                    'content-file' => 'thumb')
+        expect(after[2]).to include('type' => 'fobject',
+                                    'af-model' => 'GenericFile',
+                                    'content-file' => 'extra file.txt')
+      end
+    end
+
     describe 'decode_work_type' do
       [{ input: 'article', output: 'Article' },
        { input: 'dataset', output: 'Dataset' },
@@ -91,7 +98,7 @@ module ROF
        { input: 'etd', output: 'Etd' },
        { input: 'ETD', output: 'Etd' },
        { input: 'image', output: 'Image' }].each do |t|
-        it 'decode ' + t[:input] do
+        it 'decodes ' + t[:input] do
           w = Work.new
           result = w.decode_work_type('type' => t[:input])
           expect(result).to eq(t[:output])

--- a/spec/lib/rof/utility_spec.rb
+++ b/spec/lib/rof/utility_spec.rb
@@ -26,13 +26,6 @@ module ROF
         it { is_expected.to eq({ owner: "msuhovec", representative: nil}) }
       end
     end
-    describe 'next_label' do
-       let(:id) { util.next_label}
-
-       it 'assigns initial label' do
-         expect(id).to eq '$(pid--0)'
-       end
-    end
 
     describe '.load_items_from_json_file' do
       let(:logger) { double(puts: true) }
@@ -103,39 +96,6 @@ module ROF
           result = described_class.EncodeDoubleCaret(this_test[1])
           expect(result).to eq(this_test[0])
         end
-      end
-    end
-
-    describe 'decode_work_type' do
-
-      context 'decode article' do
-	subject { util.decode_work_type({'type' => 'article'})  }
-	it { is_expected.to eq('Article')}
-      end
-
-      context 'decode dataset' do
-	subject { util.decode_work_type({'type' => 'dataset'})  }
-	it { is_expected.to eq('Dataset')}
-      end
-
-      context 'decode document' do
-	subject { util.decode_work_type({'type' => 'document'})  }
-	it { is_expected.to eq('Document')}
-      end
-
-      context 'decode etd' do
-	subject { util.decode_work_type({'type' => 'etd'})  }
-	it { is_expected.to eq('Etd')}
-      end
-
-      context 'test downcase etd' do
-	subject { util.decode_work_type({'type' => 'ETD'})  }
-	it { is_expected.to eq('Etd')}
-      end
-
-      context 'test image' do
-	subject { util.decode_work_type({'type' => 'image'})  }
-	it { is_expected.to eq('Image')}
       end
     end
   end


### PR DESCRIPTION
* Move utility code that is only used by the Work filter into the work filter to reduce coupling.
* Use the same code to generate main and attached file rof objects
* remote `file_name` filter parameter since no one was using it
* Some extra rubocop formatting changes, mainly changing quote characters