### PR TITLE
Adjust ROF to CSV decoding to preserve ordering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in hydra-remote_identifier.gemspec
 gemspec
 
+gem 'rubocop'
+
 group :test do
   gem 'byebug'
 end


### PR DESCRIPTION
Keep the ordering of values if the metadata is not encoded using the
json-ld '@graph' construct.

Also add rubocop to the local gemfile (but not the gemspec file).