### PR TITLE
Double-caret encode structured metadata

### DIFF
--- a/lib/rof/translators/rof_to_csv.rb
+++ b/lib/rof/translators/rof_to_csv.rb
@@ -131,7 +131,15 @@ module ROF::Translators
       metadata.delete_if { |k, _v| k == '@context' || k == '@id' }
       # no Hash#transform_values in ruby 2.3.8
       result = {}
-      metadata.each { |k, v| result[k] = Array.wrap(v) }
+      metadata.each do |k, v|
+        result[k] = Array.wrap(v).map do |vv|
+          if vv.is_a?(Hash)
+            ROF::Utility.EncodeDoubleCaret(vv, true)
+          else
+            vv
+          end
+        end
+      end
       result
     end
 

--- a/spec/lib/rof/translators/rof_to_csv_spec.rb
+++ b/spec/lib/rof/translators/rof_to_csv_spec.rb
@@ -136,5 +136,93 @@ temp:01,fobject,GenericFile,0123456789,editgroup=temp:02;readgroup=public;edit=j
 "edit=und:qb98mc9021z,curate_batch_user;editgroup=und:q524jm23g92;read=wgan;readgroup=public",Etd,02,^^dc:contributor Jane Doe^^ms:role Research Director|^^dc:contributor Jane Doe^^ms:role Research Director,Zoe Braid,University of Notre Dame::College of Science::Chemistry and Biochemistry,2020-02-17,2020-01-09,a long abstract,0000000001,2020-02-22Z,All rights reserved,Adventures in Polymers,^^ms:discipline Chemistry and Biochemistry^^ms:level Doctoral Dissertation^^ms:name Doctor of Philosophy,000000001,temp:02,temp:03,fobject
 } )
     end
+
+    it "handles double caret encoded data not in a @graph" do
+      input = {
+            "pid" => "temp:02",
+            "type" => "fobject",
+            "af-model" => "Etd",
+            "rels-ext" => {
+              "@context" => {
+                "@vocab"=> "info:fedora/fedora-system:def/relations-external#",
+                "fedora-model" => "info:fedora/fedora-system:def/model#",
+                "pav" => "http://purl.org/pav/",
+                "hydra" => "http://projecthydra.org/ns/relations#",
+                "hydramata-rel" => "http://projecthydra.org/ns/relations#",
+                "hasModel" => { "@id" => "fedora-model:hasModel", "@type" => "@id" },
+                "hasEditor" => { "@id" => "hydra:hasEditor", "@type" => "@id" },
+                "hasEditorGroup" => { "@id" => "hydra:hasEditorGroup", "@type" => "@id" },
+                "hasViewer" => { "@id" => "hydra:hasViewer", "@type" => "@id" },
+                "hasViewerGroup" => { "@id" => "hydra:hasViewerGroup", "@type" => "@id" },
+                "isPartOf" => { "@type" => "@id" },
+                "isMemberOfCollection" => { "@type" => "@id" },
+                "isEditorOf" => { "@id" => "hydra:isEditorOf", "@type" => "@id" },
+                "hasMember" => { "@type" => "@id" },
+                "previousVersion" => "http://purl.org/pav/previousVersion"
+              },
+              "@id" => "temp:02",
+              "hasEditor" => "und:qb98mc9021z",
+              "hasEditorGroup" => "und:q524jm23g92"
+            },
+            "metadata" => {
+              "@context" => {
+                "bibo" => "http://purl.org/ontology/bibo/",
+                "dc" => "http://purl.org/dc/terms/",
+                "ebucore" => "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#",
+                "foaf" => "http://xmlns.com/foaf/0.1/",
+                "hydramata-rel" => "http://projecthydra.org/ns/relations#",
+                "hydra" => "http://projecthydra.org/ns/relations#",
+                "mrel" => "http://id.loc.gov/vocabulary/relators/",
+                "ms" => "http://www.ndltd.org/standards/metadata/etdms/1.1/",
+                "nd" => "https://library.nd.edu/ns/terms/",
+                "rdfs" => "http://www.w3.org/2000/01/rdf-schema#",
+                "ths" => "http://id.loc.gov/vocabulary/relators/",
+                "vracore" => "http://purl.org/vra/",
+                "pav" => "http://purl.org/pav/",
+                "dc:dateSubmitted" => { "@type" => "http://www.w3.org/2001/XMLSchema#date" },
+                "dc:created" => { "@type" => "http://www.w3.org/2001/XMLSchema#date" },
+                "dc:modified" => { "@type" => "http://www.w3.org/2001/XMLSchema#date" }
+              },
+              "@id" => "info:fedora/temp:02",
+              "dc:title" => "Adventures in Polymers",
+              "dc:date#approved" => "2020-02-17",
+              "dc:creator#administrative_unit" => "University of Notre Dame::College of Science::Chemistry and Biochemistry",
+              "dc:identifier#local" => "0000000001",
+              "dc:description#abstract" => "a long abstract",
+              "nd:alephIdentifier" => "000000001",
+                "dc:creator" => "Zoe Braid",
+                "dc:rights" => "All rights reserved",
+                "dc:modified" => "2020-02-22Z",
+                "ms:degree" => { "ms:name" => "Doctor of Philosophy",
+                                 "ms:discipline" => "Chemistry and Biochemistry",
+                                 "ms:level" => "Doctoral Dissertation"
+              },
+              "dc:dateSubmitted" => "2020-01-09",
+              "dc:contributor" => [
+                {
+                  "dc:contributor" => "Jane Doe",
+                  "ms:role" => "Research Director"
+                },
+                {
+                  "dc:contributor" => "Jane Doe",
+                  "ms:role" => "Research Director"
+                }
+              ]
+            },
+            "rights" => {
+              "read-groups" => [ "public" ],
+              "read" => [ "wgan" ],
+              "edit-groups" => [ "und:q524jm23g92" ],
+              "edit" => [ "curate_batch_user" ]
+            },
+            "properties-meta" => { "mime-type" => "text/xml" },
+            "properties" => "<fields><depositor>curate_batch_user</depositor><representative>temp:03</representative></fields>",
+            "bendo-item" => "02"
+          }
+      result = RofToCsv.call([input], {sort_keys: true})
+      expect(result).to eq(%q{access,af-model,bendo-item,dc:contributor,dc:creator,dc:creator#administrative_unit,dc:date#approved,dc:dateSubmitted,dc:description#abstract,dc:identifier#local,dc:modified,dc:rights,dc:title,ms:degree,nd:alephIdentifier,pid,representative,rof-type
+"edit=und:qb98mc9021z,curate_batch_user;editgroup=und:q524jm23g92;read=wgan;readgroup=public",Etd,02,^^dc:contributor Jane Doe^^ms:role Research Director|^^dc:contributor Jane Doe^^ms:role Research Director,Zoe Braid,University of Notre Dame::College of Science::Chemistry and Biochemistry,2020-02-17,2020-01-09,a long abstract,0000000001,2020-02-22Z,All rights reserved,Adventures in Polymers,^^ms:discipline Chemistry and Biochemistry^^ms:level Doctoral Dissertation^^ms:name Doctor of Philosophy,000000001,temp:02,temp:03,fobject
+} )
+    end
   end
 end


### PR DESCRIPTION
The fast path with the non-RDF encoded metadata left off the
double-caret encoding for more structured metadata values. This adds a
check to perform this encoding when necessary.